### PR TITLE
refactor(config): compile DNS IP filters in the parser, drop mirrored matcher enums

### DIFF
--- a/crates/xray-bench/src/lib.rs
+++ b/crates/xray-bench/src/lib.rs
@@ -48,11 +48,10 @@ use tokio::task::{JoinHandle, JoinSet};
 use tokio::time::{sleep, timeout};
 use tokio_rustls::TlsAcceptor;
 use xray_config::{
-    compile_ip_matchers, parse_xray_json, CoreConfig, DnsOutboundRule, DnsOutboundRuleAction,
-    DnsOutboundSettings, DomainMatcher, InboundConfig, InboundProtocol, IpCidr, IpMatcher,
-    Network as ConfigNetwork, OutboundConfig, OutboundSettings, RoutingConfig,
-    RoutingDomainStrategy, RoutingPortRange, RoutingRule, StreamSecurity, StreamSettings,
-    StreamTransport,
+    parse_xray_json, CoreConfig, DnsOutboundRule, DnsOutboundRuleAction, DnsOutboundSettings,
+    DomainMatcher, InboundConfig, InboundProtocol, IpCidr, Network as ConfigNetwork,
+    OutboundConfig, OutboundSettings, RoutingConfig, RoutingDomainStrategy, RoutingPortRange,
+    RoutingRule, StreamSecurity, StreamSettings, StreamTransport,
 };
 use xray_core_rs::{
     CompiledDnsOutboundPolicy, Core, DnsOutboundDecision, OutboundRouter, StartupProbeOptions,
@@ -61,11 +60,13 @@ use xray_proxy::vless::{
     encode_udp_packet, encode_xudp_keep_packet, read_udp_packet, read_xudp_packet,
     unpad_vision_block, VisionCommand, VisionPadding,
 };
-use xray_routing::{Network as RoutingNetwork, Target, TargetAddr as RoutingTargetAddr};
+use xray_routing::{
+    Cidr, DnsIpFilter, IpMatcherSet, Network as RoutingNetwork, Target,
+    TargetAddr as RoutingTargetAddr,
+};
 use xray_transport::{
-    select_name_server_indices, CachingDnsResolver, CompiledDnsIpFilter,
-    CompiledNameServerPolicies, DnsIpFilter, DnsIpMatcher, DnsLookup, DnsResolver, NameServer,
-    NameServerPolicy, TransportDomainMatcher, TransportError,
+    select_name_server_indices, CachingDnsResolver, CompiledNameServerPolicies, DnsLookup,
+    DnsResolver, NameServer, NameServerPolicy, TransportDomainMatcher, TransportError,
 };
 use xray_utls::{normalize_reality_supported_fingerprint, XRAY_REALITY_CAPABLE_FINGERPRINTS};
 
@@ -8592,14 +8593,18 @@ fn measure_dns_ip_filter(
     matcher_count: usize,
     iterations: usize,
 ) -> Result<DnsIpFilterProbeMetric, BenchError> {
-    let matchers = (0..matcher_count)
-        .map(|index| DnsIpMatcher::host(dns_ip_filter_probe_address(index)))
-        .collect();
     let target = dns_ip_filter_probe_address(matcher_count - 1);
     let non_match = dns_ip_filter_probe_miss(target);
 
+    let addresses = (0..matcher_count)
+        .map(dns_ip_filter_probe_address)
+        .collect::<Vec<_>>();
     let started = Instant::now();
-    let filter = CompiledDnsIpFilter::new(DnsIpFilter::hard(matchers, Vec::new()));
+    let mut builder = DnsIpFilter::builder();
+    for address in addresses {
+        builder.custom().insert_ip(address, false);
+    }
+    let filter = builder.build();
     let compile_us = started.elapsed().as_micros();
     let hit_matched = filter.matches(target);
     let miss_rejected = !filter.matches(non_match);
@@ -9771,23 +9776,23 @@ fn route_probe_config(
 
     let mut routing_rules = Vec::with_capacity(rules);
     for index in 0..rules {
-        let ip_matchers = if index + 1 == rules {
-            vec![IpMatcher::Cidr(IpCidr::full(IpAddr::V4(
-                ROUTE_PROBE_TARGET_IP,
-            )))]
+        let mut ip_matchers = IpMatcherSet::builder();
+        if index + 1 == rules {
+            ip_matchers.insert_cidr(Cidr::host(IpAddr::V4(ROUTE_PROBE_TARGET_IP)), false);
         } else {
-            (0..cidrs_per_rule)
-                .map(|cidr_index| {
-                    route_probe_miss_cidr(index, cidr_index, cidrs_per_rule).map(IpMatcher::Cidr)
-                })
-                .collect::<Result<Vec<_>, _>>()?
-        };
+            for cidr_index in 0..cidrs_per_rule {
+                ip_matchers.insert_cidr(
+                    route_probe_miss_cidr(index, cidr_index, cidrs_per_rule)?.cidr(),
+                    false,
+                );
+            }
+        }
         routing_rules.push(RoutingRule {
             inbound_tags: vec!["bench-in".to_owned()],
             networks: Vec::new(),
             port_ranges: Vec::new(),
             domain_matchers: Vec::new(),
-            ip_matchers: compile_ip_matchers(&ip_matchers),
+            ip_matchers: ip_matchers.build(),
             outbound_tag: selected_tag.clone(),
         });
     }

--- a/crates/xray-config/src/geodata.rs
+++ b/crates/xray-config/src/geodata.rs
@@ -9,8 +9,9 @@ use std::{
 
 use prost::Message;
 use thiserror::Error;
+use xray_routing::IpMatcherSetBuilder;
 
-use crate::{ConfigModelError, DomainMatcher, IpCidr, IpMatcher, RegexMatcher};
+use crate::{ConfigModelError, DomainMatcher, IpCidr, RegexMatcher};
 
 const MAX_GEODATA_FILE_SIZE: u64 = 128 * 1024 * 1024;
 const MAX_GEODATA_ENTRY_SIZE: usize = 32 * 1024 * 1024;
@@ -149,14 +150,24 @@ impl GeodataLoader {
         }
     }
 
+    /// Inserts the routing IP rules of `file_name:code` into `matchers` and
+    /// returns how many were inserted.
     pub(crate) fn load_ip_matchers(
         &mut self,
         file_name: &str,
         code: &str,
         inverse: bool,
         max_matchers: usize,
-    ) -> Result<Vec<IpMatcher>, GeodataError> {
-        self.load_ip_matchers_with_asset_reverse(file_name, code, inverse, max_matchers, true)
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Result<usize, GeodataError> {
+        self.load_ip_matchers_with_asset_reverse(
+            file_name,
+            code,
+            inverse,
+            max_matchers,
+            true,
+            matchers,
+        )
     }
 
     /// Loads Xray DNS IP rules without the legacy asset-level `reverse_match` flag.
@@ -166,8 +177,16 @@ impl GeodataLoader {
         code: &str,
         inverse: bool,
         max_matchers: usize,
-    ) -> Result<Vec<IpMatcher>, GeodataError> {
-        self.load_ip_matchers_with_asset_reverse(file_name, code, inverse, max_matchers, false)
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Result<usize, GeodataError> {
+        self.load_ip_matchers_with_asset_reverse(
+            file_name,
+            code,
+            inverse,
+            max_matchers,
+            false,
+            matchers,
+        )
     }
 
     fn load_ip_matchers_with_asset_reverse(
@@ -177,7 +196,8 @@ impl GeodataLoader {
         inverse: bool,
         max_matchers: usize,
         apply_asset_reverse: bool,
-    ) -> Result<Vec<IpMatcher>, GeodataError> {
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Result<usize, GeodataError> {
         let code = normalize_code(code);
         let geoip = self.load_ip(file_name, &code)?;
         if geoip.cidr.len() > max_matchers {
@@ -189,18 +209,14 @@ impl GeodataLoader {
             });
         }
         let inverse = inverse ^ (apply_asset_reverse && geoip.reverse_match);
-        geoip
-            .cidr
-            .iter()
-            .map(|cidr| {
-                let matcher = IpMatcher::Cidr(cidr_to_ip_cidr(cidr, file_name, &code)?);
-                #[cfg(test)]
-                {
-                    self.ip_matcher_builds += 1;
-                }
-                Ok(wrap_inverse(matcher, inverse))
-            })
-            .collect()
+        for cidr in &geoip.cidr {
+            matchers.insert_cidr(cidr_to_ip_cidr(cidr, file_name, &code)?.cidr(), inverse);
+            #[cfg(test)]
+            {
+                self.ip_matcher_builds += 1;
+            }
+        }
+        Ok(geoip.cidr.len())
     }
 
     fn load_site(&mut self, file_name: &str, code: &str) -> Result<Arc<GeoSite>, GeodataError> {
@@ -1069,14 +1085,6 @@ fn cidr_to_ip_cidr(cidr: &GeoCidr, file_name: &str, code: &str) -> Result<IpCidr
     })
 }
 
-fn wrap_inverse(matcher: IpMatcher, inverse: bool) -> IpMatcher {
-    if inverse {
-        IpMatcher::Not(Box::new(matcher))
-    } else {
-        matcher
-    }
-}
-
 fn normalize_code(code: &str) -> String {
     code.to_ascii_uppercase()
 }
@@ -1143,6 +1151,7 @@ mod tests {
     };
 
     use prost::Message;
+    use xray_routing::IpMatcherSet;
 
     use super::{
         find_entry_body, scan_entry_code, validate_geo_site_body, GeoCidr, GeoDomain,
@@ -1524,14 +1533,16 @@ mod tests {
         let mut loader = GeodataLoader::from_dirs(Vec::new());
         loader.ips.insert(key, cached);
 
+        let mut matchers = IpMatcherSet::builder();
         let first = loader
-            .load_ip_matchers("geoip.dat", "TEST", false, 2)
+            .load_ip_matchers("geoip.dat", "TEST", false, 2, &mut matchers)
             .unwrap();
         let error = loader
-            .load_ip_matchers("geoip.dat", "TEST", false, 1)
+            .load_ip_matchers("geoip.dat", "TEST", false, 1, &mut matchers)
             .unwrap_err();
 
-        assert_eq!(first.len(), 2);
+        assert_eq!(first, 2);
+        assert_eq!(matchers.matcher_count(), 2);
         assert!(matches!(
             error,
             GeodataError::IpMatcherBudgetExceeded {

--- a/crates/xray-config/src/lib.rs
+++ b/crates/xray-config/src/lib.rs
@@ -5,19 +5,19 @@ mod parser;
 
 pub use diagnostic::{Diagnostic, DiagnosticSeverity};
 pub use model::{
-    compile_ip_matchers, ConfigModelError, CoreConfig, DnsConfig, DnsFakeIpConfig, DnsHostMapping,
-    DnsHostTarget, DnsIpFilter, DnsNameServerConfig, DnsOutboundRule, DnsOutboundRuleAction,
-    DnsOutboundSettings, DnsQTypeRange, DnsQueryStrategy, DnsServerConfig, DnsServerEndpoint,
-    DnsServerTransport, DomainMatcher, GrpcSettings, HappyEyeballsSettings, HttpUpgradeSettings,
-    InboundConfig, InboundProtocol, InboundSniffingConfig, IpCidr, IpMatcher, IpMatcherSet,
-    Network, OutboundConfig, OutboundProtocol, OutboundSettings, PolicyConfig, PolicyLevelConfig,
-    PolicySystemConfig, QuicBbrProfile, QuicCongestion, QuicIntervalRange, QuicParamsSettings,
-    QuicUdpHopSettings, RealitySettings, RealityShortId, RegexMatcher, RoutingConfig,
-    RoutingDomainStrategy, RoutingPortRange, RoutingRule, SniffingDestination, SocketOptions,
-    StreamSecurity, StreamSettings, StreamTransport, TargetAddr, TlsSettings,
-    VlessOutboundSettings, VlessUser, WebSocketSettings, XhttpMode, XhttpPaddingMethod,
-    XhttpPaddingPlacement, XhttpPlacement, XhttpRange, XhttpSettings, XhttpUplinkDataPlacement,
-    XhttpXmuxSettings, DEFAULT_DNS_SERVER_TIMEOUT_MS, MAX_DNS_SERVER_TIMEOUT_MS,
+    ConfigModelError, CoreConfig, DnsConfig, DnsFakeIpConfig, DnsHostMapping, DnsHostTarget,
+    DnsIpFilter, DnsNameServerConfig, DnsOutboundRule, DnsOutboundRuleAction, DnsOutboundSettings,
+    DnsQTypeRange, DnsQueryStrategy, DnsServerConfig, DnsServerEndpoint, DnsServerTransport,
+    DomainMatcher, GrpcSettings, HappyEyeballsSettings, HttpUpgradeSettings, InboundConfig,
+    InboundProtocol, InboundSniffingConfig, IpCidr, IpMatcherSet, Network, OutboundConfig,
+    OutboundProtocol, OutboundSettings, PolicyConfig, PolicyLevelConfig, PolicySystemConfig,
+    QuicBbrProfile, QuicCongestion, QuicIntervalRange, QuicParamsSettings, QuicUdpHopSettings,
+    RealitySettings, RealityShortId, RegexMatcher, RoutingConfig, RoutingDomainStrategy,
+    RoutingPortRange, RoutingRule, SniffingDestination, SocketOptions, StreamSecurity,
+    StreamSettings, StreamTransport, TargetAddr, TlsSettings, VlessOutboundSettings, VlessUser,
+    WebSocketSettings, XhttpMode, XhttpPaddingMethod, XhttpPaddingPlacement, XhttpPlacement,
+    XhttpRange, XhttpSettings, XhttpUplinkDataPlacement, XhttpXmuxSettings,
+    DEFAULT_DNS_SERVER_TIMEOUT_MS, MAX_DNS_SERVER_TIMEOUT_MS,
 };
 pub use parser::{
     parse_xray_json, parse_xray_json_with_exclusive_geodata_dirs, parse_xray_json_with_geodata_dir,

--- a/crates/xray-config/src/model.rs
+++ b/crates/xray-config/src/model.rs
@@ -6,8 +6,8 @@ use std::{
 
 use regex::Regex;
 use uuid::Uuid;
-pub use xray_routing::IpMatcherSet;
-use xray_routing::{Cidr, IpMatcherSetBuilder};
+use xray_routing::Cidr;
+pub use xray_routing::{DnsIpFilter, IpMatcherSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum ConfigModelError {
@@ -93,7 +93,7 @@ pub const MAX_DNS_SERVER_TIMEOUT_MS: u64 = i64::MAX as u64 / 2 / 1_000_000;
 pub enum DnsServerConfig {
     Ip(SocketAddr),
     Domain { domain: String, port: u16 },
-    Policy(DnsNameServerConfig),
+    Policy(Box<DnsNameServerConfig>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,19 +110,6 @@ pub struct DnsNameServerConfig {
     pub skip_fallback: bool,
     pub query_strategy: DnsQueryStrategy,
     pub final_query: bool,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DnsIpFilter {
-    pub custom_matchers: Vec<IpMatcher>,
-    pub geoip_matchers: Vec<IpMatcher>,
-    pub soft: bool,
-}
-
-impl DnsIpFilter {
-    pub fn is_empty(&self) -> bool {
-        self.custom_matchers.is_empty() && self.geoip_matchers.is_empty()
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -341,22 +328,6 @@ impl RoutingPortRange {
     }
 }
 
-pub fn compile_ip_matchers(matchers: &[IpMatcher]) -> IpMatcherSet {
-    let mut builder = IpMatcherSet::builder();
-    for matcher in matchers {
-        insert_ip_matcher(&mut builder, matcher, false);
-    }
-    builder.build()
-}
-
-fn insert_ip_matcher(builder: &mut IpMatcherSetBuilder, matcher: &IpMatcher, inverted: bool) {
-    match matcher {
-        IpMatcher::Cidr(cidr) => builder.insert_cidr(cidr.0, inverted),
-        IpMatcher::Private => builder.insert_private_networks(inverted),
-        IpMatcher::Not(inner) => insert_ip_matcher(builder, inner, !inverted),
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DomainMatcher {
     Keyword(String),
@@ -443,13 +414,6 @@ fn domain_matches_suffix(domain: &str, suffix: &str) -> bool {
         && domain_bytes[boundary_index + 1..].eq_ignore_ascii_case(suffix.as_bytes())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IpMatcher {
-    Cidr(IpCidr),
-    Private,
-    Not(Box<IpMatcher>),
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct IpCidr(Cidr);
 
@@ -465,6 +429,10 @@ impl IpCidr {
 
     pub const fn full(ip: IpAddr) -> Self {
         Self(Cidr::host(ip))
+    }
+
+    pub const fn cidr(self) -> Cidr {
+        self.0
     }
 
     pub fn network(&self) -> IpAddr {
@@ -1107,7 +1075,7 @@ impl TargetAddr {
     /// transport-security requirement.
     ///
     /// This intentionally uses Xray's broader private/reserved/test set, not
-    /// the routing-oriented [`IpMatcher::Private`] set. Xray normalizes one
+    /// the routing-oriented `geoip:private` set ([`xray_routing::PRIVATE_NETWORKS`]). Xray normalizes one
     /// trailing domain dot and domain case before applying these rules.
     pub fn is_xray_plaintext_server_exempt(&self) -> bool {
         match self {
@@ -1213,12 +1181,28 @@ const XRAY_PLAINTEXT_SERVER_CIDRS: [IpCidr; 18] = [
 mod tests {
     use super::*;
 
-    fn cidr(a: u8, b: u8, c: u8, d: u8, prefix: u8) -> IpMatcher {
-        IpMatcher::Cidr(IpCidr::new(IpAddr::V4(Ipv4Addr::new(a, b, c, d)), prefix).unwrap())
+    #[derive(Clone, Copy)]
+    enum Matcher {
+        Cidr(Cidr, bool),
+        Private(bool),
     }
 
-    fn not(matcher: IpMatcher) -> IpMatcher {
-        IpMatcher::Not(Box::new(matcher))
+    fn cidr(a: u8, b: u8, c: u8, d: u8, prefix: u8) -> Matcher {
+        Matcher::Cidr(
+            Cidr::new(IpAddr::V4(Ipv4Addr::new(a, b, c, d)), prefix).unwrap(),
+            false,
+        )
+    }
+
+    fn private() -> Matcher {
+        Matcher::Private(false)
+    }
+
+    fn not(matcher: Matcher) -> Matcher {
+        match matcher {
+            Matcher::Cidr(cidr, inverted) => Matcher::Cidr(cidr, !inverted),
+            Matcher::Private(inverted) => Matcher::Private(!inverted),
+        }
     }
 
     fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
@@ -1233,8 +1217,15 @@ mod tests {
         IpAddr::V6(Ipv4Addr::new(a, b, c, d).to_ipv6_mapped())
     }
 
-    fn set(matchers: Vec<IpMatcher>) -> IpMatcherSet {
-        compile_ip_matchers(&matchers)
+    fn set(matchers: Vec<Matcher>) -> IpMatcherSet {
+        let mut builder = IpMatcherSet::builder();
+        for matcher in matchers {
+            match matcher {
+                Matcher::Cidr(cidr, inverted) => builder.insert_cidr(cidr, inverted),
+                Matcher::Private(inverted) => builder.insert_private_networks(inverted),
+            }
+        }
+        builder.build()
     }
 
     #[test]
@@ -1313,10 +1304,14 @@ mod tests {
         assert!(!matchers.matches(mapped(203, 0, 114, 7)));
         assert!(set(vec![cidr(203, 0, 113, 0, 24)]).matches(mapped(203, 0, 113, 7)));
 
-        let mapped_network =
-            IpMatcher::Cidr(IpCidr::new(mapped(203, 0, 113, 0), 24).expect("v4 prefix"));
+        let mapped_network = Matcher::Cidr(
+            IpCidr::new(mapped(203, 0, 113, 0), 24)
+                .expect("v4 prefix")
+                .cidr(),
+            false,
+        );
         assert_eq!(
-            set(vec![mapped_network.clone()]),
+            set(vec![mapped_network]),
             set(vec![cidr(203, 0, 113, 0, 24)])
         );
         assert!(set(vec![mapped_network]).matches(v4(203, 0, 113, 7)));
@@ -1337,9 +1332,11 @@ mod tests {
             !set(vec![not(cidr(10, 0, 0, 0, 8))]).matches(v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1]))
         );
 
-        let fc00 =
-            IpMatcher::Cidr(IpCidr::new(v6([0xfc00, 0, 0, 0, 0, 0, 0, 0]), 7).expect("v6 prefix"));
-        let matchers = set(vec![not(cidr(10, 0, 0, 0, 8)), not(fc00.clone())]);
+        let fc00 = Matcher::Cidr(
+            Cidr::new(v6([0xfc00, 0, 0, 0, 0, 0, 0, 0]), 7).expect("v6 prefix"),
+            false,
+        );
+        let matchers = set(vec![not(cidr(10, 0, 0, 0, 8)), not(fc00)]);
         assert!(matchers.matches(v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1])));
         assert!(!matchers.matches(v6([0xfd00, 0, 0, 0, 0, 0, 0, 1])));
         assert!(matchers.matches(v4(8, 8, 8, 8)));
@@ -1390,14 +1387,14 @@ mod tests {
 
     #[test]
     fn ip_matcher_set_private_and_its_inverse() {
-        let private = set(vec![IpMatcher::Private]);
-        assert_eq!(private.range_count(), 9);
-        assert!(private.matches(v4(10, 1, 2, 3)));
-        assert!(private.matches(mapped(192, 168, 1, 1)));
-        assert!(private.matches(v6([0xfe80, 0, 0, 0, 0, 0, 0, 1])));
-        assert!(!private.matches(v4(8, 8, 8, 8)));
+        let private_set = set(vec![private()]);
+        assert_eq!(private_set.range_count(), 9);
+        assert!(private_set.matches(v4(10, 1, 2, 3)));
+        assert!(private_set.matches(mapped(192, 168, 1, 1)));
+        assert!(private_set.matches(v6([0xfe80, 0, 0, 0, 0, 0, 0, 1])));
+        assert!(!private_set.matches(v4(8, 8, 8, 8)));
 
-        let public = set(vec![not(IpMatcher::Private)]);
+        let public = set(vec![not(private())]);
         assert_eq!(public.range_count(), 9);
         assert!(public.matches(v4(8, 8, 8, 8)));
         assert!(public.matches(v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1])));
@@ -1405,26 +1402,28 @@ mod tests {
         assert!(!public.matches(mapped(192, 168, 1, 1)));
         assert!(!public.matches(IpAddr::V6(Ipv6Addr::LOCALHOST)));
         assert!(!public.matches(v6([0xfe80, 0, 0, 0, 0, 0, 0, 1])));
-        assert!(set(vec![not(IpMatcher::Private)]).matches(v4(8, 8, 8, 8)));
-        assert!(!set(vec![not(IpMatcher::Private)]).matches(v4(10, 0, 0, 1)));
+        assert!(set(vec![not(private())]).matches(v4(8, 8, 8, 8)));
+        assert!(!set(vec![not(private())]).matches(v4(10, 0, 0, 1)));
     }
 
     #[test]
     fn private_matcher_uses_shared_private_networks() {
-        assert!(set(vec![IpMatcher::Private]).matches(v4(10, 1, 2, 3)));
-        assert!(set(vec![IpMatcher::Private]).matches(v4(100, 64, 0, 1)));
-        assert!(set(vec![IpMatcher::Private]).matches(v4(127, 0, 0, 1)));
-        assert!(set(vec![IpMatcher::Private]).matches(v4(169, 254, 1, 1)));
-        assert!(set(vec![IpMatcher::Private]).matches(v4(172, 31, 255, 255)));
-        assert!(set(vec![IpMatcher::Private]).matches(v4(192, 168, 0, 1)));
-        assert!(set(vec![IpMatcher::Private]).matches(IpAddr::V6(Ipv6Addr::LOCALHOST)));
-        assert!(set(vec![IpMatcher::Private])
-            .matches(IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1))));
-        assert!(set(vec![IpMatcher::Private])
-            .matches(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1))));
-        assert!(!set(vec![IpMatcher::Private]).matches(v4(8, 8, 8, 8)));
-        assert!(!set(vec![IpMatcher::Private]).matches(v4(172, 32, 0, 1)));
-        assert!(!set(vec![IpMatcher::Private])
+        assert!(set(vec![private()]).matches(v4(10, 1, 2, 3)));
+        assert!(set(vec![private()]).matches(v4(100, 64, 0, 1)));
+        assert!(set(vec![private()]).matches(v4(127, 0, 0, 1)));
+        assert!(set(vec![private()]).matches(v4(169, 254, 1, 1)));
+        assert!(set(vec![private()]).matches(v4(172, 31, 255, 255)));
+        assert!(set(vec![private()]).matches(v4(192, 168, 0, 1)));
+        assert!(set(vec![private()]).matches(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(
+            set(vec![private()]).matches(IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1)))
+        );
+        assert!(
+            set(vec![private()]).matches(IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1)))
+        );
+        assert!(!set(vec![private()]).matches(v4(8, 8, 8, 8)));
+        assert!(!set(vec![private()]).matches(v4(172, 32, 0, 1)));
+        assert!(!set(vec![private()])
             .matches(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))));
     }
 

--- a/crates/xray-config/src/parser.rs
+++ b/crates/xray-config/src/parser.rs
@@ -6,23 +6,22 @@ use std::{
 
 use serde_json::Value;
 use uuid::Uuid;
+use xray_routing::{IpMatcherSet, IpMatcherSetBuilder};
 
 use crate::{
-    compile_ip_matchers,
     geodata::{default_geodata_dirs, GeodataLoader},
     CoreConfig, Diagnostic, DnsConfig, DnsFakeIpConfig, DnsHostMapping, DnsHostTarget, DnsIpFilter,
     DnsNameServerConfig, DnsOutboundRule, DnsOutboundRuleAction, DnsOutboundSettings,
     DnsQTypeRange, DnsQueryStrategy, DnsServerConfig, DnsServerEndpoint, DnsServerTransport,
     DomainMatcher, GrpcSettings, HappyEyeballsSettings, HttpUpgradeSettings, InboundConfig,
-    InboundProtocol, InboundSniffingConfig, IpCidr, IpMatcher, Network, OutboundConfig,
-    OutboundProtocol, OutboundSettings, PolicyConfig, PolicyLevelConfig, PolicySystemConfig,
-    QuicBbrProfile, QuicCongestion, QuicIntervalRange, QuicParamsSettings, QuicUdpHopSettings,
-    RealitySettings, RealityShortId, RegexMatcher, RoutingConfig, RoutingDomainStrategy,
-    RoutingPortRange, RoutingRule, SniffingDestination, SocketOptions, StreamSecurity,
-    StreamSettings, StreamTransport, TargetAddr, TlsSettings, VlessOutboundSettings, VlessUser,
-    WebSocketSettings, XhttpMode, XhttpPaddingMethod, XhttpPaddingPlacement, XhttpPlacement,
-    XhttpRange, XhttpSettings, XhttpUplinkDataPlacement, XhttpXmuxSettings,
-    MAX_DNS_SERVER_TIMEOUT_MS,
+    InboundProtocol, InboundSniffingConfig, IpCidr, Network, OutboundConfig, OutboundProtocol,
+    OutboundSettings, PolicyConfig, PolicyLevelConfig, PolicySystemConfig, QuicBbrProfile,
+    QuicCongestion, QuicIntervalRange, QuicParamsSettings, QuicUdpHopSettings, RealitySettings,
+    RealityShortId, RegexMatcher, RoutingConfig, RoutingDomainStrategy, RoutingPortRange,
+    RoutingRule, SniffingDestination, SocketOptions, StreamSecurity, StreamSettings,
+    StreamTransport, TargetAddr, TlsSettings, VlessOutboundSettings, VlessUser, WebSocketSettings,
+    XhttpMode, XhttpPaddingMethod, XhttpPaddingPlacement, XhttpPlacement, XhttpRange,
+    XhttpSettings, XhttpUplinkDataPlacement, XhttpXmuxSettings, MAX_DNS_SERVER_TIMEOUT_MS,
 };
 
 const MAX_ROUTING_RULES: usize = 4_096;
@@ -261,7 +260,7 @@ fn dns_tcp_server_policy(
     transport: DnsServerTransport,
     endpoint: DnsServerEndpoint,
 ) -> DnsServerConfig {
-    DnsServerConfig::Policy(DnsNameServerConfig {
+    DnsServerConfig::Policy(Box::new(DnsNameServerConfig {
         endpoint,
         transport,
         domains: Vec::new(),
@@ -272,7 +271,7 @@ fn dns_tcp_server_policy(
         skip_fallback: false,
         query_strategy: DnsQueryStrategy::UseIp,
         final_query: false,
-    })
+    }))
 }
 
 fn fake_ip_usable_address_count(pool: IpCidr) -> u64 {
@@ -752,7 +751,7 @@ impl Parser<'_> {
             return None;
         }
 
-        Some(DnsServerConfig::Policy(DnsNameServerConfig {
+        Some(DnsServerConfig::Policy(Box::new(DnsNameServerConfig {
             endpoint,
             transport,
             domains,
@@ -770,7 +769,7 @@ impl Parser<'_> {
             final_query: self
                 .optional_bool_at(server, "finalQuery", format!("{path}.finalQuery"))
                 .unwrap_or(false),
-        }))
+        })))
     }
 
     fn parse_dns_server_ip_filters(
@@ -830,32 +829,30 @@ impl Parser<'_> {
     }
 
     fn parse_dns_ip_filter(&mut self, values: &[&str], path: &str) -> Option<DnsIpFilter> {
-        let mut filter = DnsIpFilter::default();
+        let mut filter = DnsIpFilter::builder();
         for (index, value) in values.iter().copied().enumerate() {
             if value == "*" {
-                filter.soft = true;
+                filter.set_soft(true);
                 continue;
             }
 
             let item_path = format!("{path}[{index}]");
-            let remaining = self.matcher_budget.remaining_ip_matchers();
-            if remaining == 0 {
+            if self.matcher_budget.remaining_ip_matchers() == 0 {
                 self.ip_matcher_budget_error(&item_path);
                 return None;
             }
-            let is_geoip = dns_ip_rule_uses_geodata(value);
-            let matchers = self.parse_dns_ip_matcher(value, &item_path, remaining)?;
-            if !self.matcher_budget.consume_ip_matchers(matchers.len()) {
-                self.ip_matcher_budget_error(&item_path);
-                return None;
-            }
-            if is_geoip {
-                filter.geoip_matchers.extend(matchers);
+            let matchers = if dns_ip_rule_uses_geodata(value) {
+                filter.geoip()
             } else {
-                filter.custom_matchers.extend(matchers);
+                filter.custom()
+            };
+            let inserted = self.parse_dns_ip_matcher(value, &item_path, matchers)?;
+            if !self.matcher_budget.consume_ip_matchers(inserted) {
+                self.ip_matcher_budget_error(&item_path);
+                return None;
             }
         }
-        Some(filter)
+        Some(filter.build())
     }
 
     fn parse_dns_server_endpoint(
@@ -1508,7 +1505,7 @@ impl Parser<'_> {
             networks,
             port_ranges,
             domain_matchers,
-            ip_matchers: compile_ip_matchers(&ip_matchers),
+            ip_matchers,
             outbound_tag: outbound_tag.to_owned(),
         })
     }
@@ -5054,19 +5051,15 @@ impl Parser<'_> {
         value: &Value,
         key: &str,
         path: String,
-    ) -> Option<Vec<IpMatcher>> {
+    ) -> Option<IpMatcherSet> {
         let Some(raw) = value.get(key) else {
-            return Some(Vec::new());
+            return Some(IpMatcherSet::default());
         };
         let Some(values) = raw.as_array() else {
             self.error(path, format!("field `{key}` must be an array"));
             return None;
         };
-        let mut matchers = Vec::with_capacity(
-            values
-                .len()
-                .min(self.matcher_budget.remaining_ip_matchers()),
-        );
+        let mut matchers = IpMatcherSet::builder();
 
         for (index, value) in values.iter().enumerate() {
             let item_path = format!("{path}[{index}]");
@@ -5079,50 +5072,45 @@ impl Parser<'_> {
                 return None;
             }
 
-            let remaining = self.matcher_budget.remaining_ip_matchers();
-            if remaining == 0 {
+            if self.matcher_budget.remaining_ip_matchers() == 0 {
                 self.ip_matcher_budget_error(&item_path);
                 return None;
             }
-            let parsed_matchers = self.parse_ip_matcher(value, &item_path, remaining)?;
-            if !self
-                .matcher_budget
-                .consume_ip_matchers(parsed_matchers.len())
-            {
+            let inserted = self.parse_ip_matcher(value, &item_path, &mut matchers)?;
+            if !self.matcher_budget.consume_ip_matchers(inserted) {
                 self.ip_matcher_budget_error(&item_path);
                 return None;
             }
-            matchers.extend(parsed_matchers);
         }
 
-        Some(matchers)
+        Some(matchers.build())
     }
 
     fn parse_ip_matcher(
         &mut self,
         value: &str,
         path: &str,
-        max_matchers: usize,
-    ) -> Option<Vec<IpMatcher>> {
-        self.parse_ip_matcher_with_mode(value, path, max_matchers, IpMatcherParseMode::Routing)
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Option<usize> {
+        self.parse_ip_matcher_with_mode(value, path, IpMatcherParseMode::Routing, matchers)
     }
 
     fn parse_dns_ip_matcher(
         &mut self,
         value: &str,
         path: &str,
-        max_matchers: usize,
-    ) -> Option<Vec<IpMatcher>> {
-        self.parse_ip_matcher_with_mode(value, path, max_matchers, IpMatcherParseMode::XrayDns)
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Option<usize> {
+        self.parse_ip_matcher_with_mode(value, path, IpMatcherParseMode::XrayDns, matchers)
     }
 
     fn parse_ip_matcher_with_mode(
         &mut self,
         value: &str,
         path: &str,
-        max_matchers: usize,
         mode: IpMatcherParseMode,
-    ) -> Option<Vec<IpMatcher>> {
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Option<usize> {
         let (value, inverse) = strip_inverse_prefix(value);
         if let Some(code) = value.strip_prefix("geoip:") {
             let (code, code_inverse) = strip_inverse_prefix(code);
@@ -5132,20 +5120,22 @@ impl Parser<'_> {
                 return None;
             }
             if mode == IpMatcherParseMode::Routing && code.eq_ignore_ascii_case("private") {
-                return Some(vec![wrap_ip_matcher_inverse(IpMatcher::Private, inverse)]);
+                matchers.insert_private_networks(inverse);
+                return Some(1);
             }
-            return self.parse_geoip_matchers("geoip.dat", code, inverse, path, max_matchers, mode);
+            return self.parse_geoip_matchers("geoip.dat", code, inverse, path, mode, matchers);
         }
 
         if let Some(spec) = value.strip_prefix("ext-ip:") {
-            return self.parse_external_geoip_matchers(spec, inverse, path, max_matchers, mode);
+            return self.parse_external_geoip_matchers(spec, inverse, path, mode, matchers);
         }
         if let Some(spec) = value.strip_prefix("ext:") {
-            return self.parse_external_geoip_matchers(spec, inverse, path, max_matchers, mode);
+            return self.parse_external_geoip_matchers(spec, inverse, path, mode, matchers);
         }
 
-        self.parse_ip_cidr(value, path)
-            .map(|cidr| vec![wrap_ip_matcher_inverse(IpMatcher::Cidr(cidr), inverse)])
+        let cidr = self.parse_ip_cidr(value, path)?;
+        matchers.insert_cidr(cidr.cidr(), inverse);
+        Some(1)
     }
 
     fn parse_external_geoip_matchers(
@@ -5153,9 +5143,9 @@ impl Parser<'_> {
         spec: &str,
         inverse: bool,
         path: &str,
-        max_matchers: usize,
         mode: IpMatcherParseMode,
-    ) -> Option<Vec<IpMatcher>> {
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Option<usize> {
         let (file_name, code) = self.parse_external_geodata_ref(spec, path)?;
         let (code, code_inverse) = strip_inverse_prefix(code);
         let inverse = inverse ^ code_inverse;
@@ -5164,7 +5154,7 @@ impl Parser<'_> {
             return None;
         }
 
-        self.parse_geoip_matchers(file_name, code, inverse, path, max_matchers, mode)
+        self.parse_geoip_matchers(file_name, code, inverse, path, mode, matchers)
     }
 
     fn parse_geoip_matchers(
@@ -5173,28 +5163,35 @@ impl Parser<'_> {
         code: &str,
         inverse: bool,
         path: &str,
-        max_matchers: usize,
         mode: IpMatcherParseMode,
-    ) -> Option<Vec<IpMatcher>> {
-        let matchers = match mode {
-            IpMatcherParseMode::Routing => {
-                self.geodata_loader
-                    .load_ip_matchers(file_name, code, inverse, max_matchers)
-            }
-            IpMatcherParseMode::XrayDns => {
-                self.geodata_loader
-                    .load_dns_ip_matchers(file_name, code, inverse, max_matchers)
-            }
+        matchers: &mut IpMatcherSetBuilder,
+    ) -> Option<usize> {
+        let max_matchers = self.matcher_budget.remaining_ip_matchers();
+        let inserted = match mode {
+            IpMatcherParseMode::Routing => self.geodata_loader.load_ip_matchers(
+                file_name,
+                code,
+                inverse,
+                max_matchers,
+                matchers,
+            ),
+            IpMatcherParseMode::XrayDns => self.geodata_loader.load_dns_ip_matchers(
+                file_name,
+                code,
+                inverse,
+                max_matchers,
+                matchers,
+            ),
         };
-        match matchers {
-            Ok(matchers) if matchers.is_empty() => {
+        match inserted {
+            Ok(0) => {
                 self.error(
                     path,
                     format!("geoip `{file_name}:{code}` produced no IP matchers"),
                 );
                 None
             }
-            Ok(matchers) => Some(matchers),
+            Ok(inserted) => Some(inserted),
             Err(error) => {
                 self.error(path, error.to_string());
                 None
@@ -6071,14 +6068,6 @@ fn normalize_xray_address_text(mut value: &str) -> &str {
 
 fn parse_xray_ip_address(value: &str) -> Option<IpAddr> {
     normalize_xray_address_text(value).parse().ok()
-}
-
-fn wrap_ip_matcher_inverse(matcher: IpMatcher, inverse: bool) -> IpMatcher {
-    if inverse {
-        IpMatcher::Not(Box::new(matcher))
-    } else {
-        matcher
-    }
 }
 
 fn is_loopback_listener(listen: &str) -> bool {

--- a/crates/xray-config/tests/model_tests.rs
+++ b/crates/xray-config/tests/model_tests.rs
@@ -1,17 +1,17 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use xray_config::{
-    compile_ip_matchers, CoreConfig, Diagnostic, DiagnosticSeverity, DnsConfig, DnsIpFilter,
-    DnsOutboundRule, DnsOutboundRuleAction, DnsOutboundSettings, DnsQTypeRange, DnsQueryStrategy,
-    DomainMatcher, HappyEyeballsSettings, InboundConfig, InboundProtocol, IpCidr, IpMatcher,
-    Network, OutboundConfig, OutboundProtocol, OutboundSettings, RealitySettings, RealityShortId,
+    CoreConfig, Diagnostic, DiagnosticSeverity, DnsConfig, DnsIpFilter, DnsOutboundRule,
+    DnsOutboundRuleAction, DnsOutboundSettings, DnsQTypeRange, DnsQueryStrategy, DomainMatcher,
+    HappyEyeballsSettings, InboundConfig, InboundProtocol, IpCidr, IpMatcherSet, Network,
+    OutboundConfig, OutboundProtocol, OutboundSettings, RealitySettings, RealityShortId,
     RegexMatcher, RoutingConfig, RoutingPortRange, RoutingRule, SocketOptions, StreamSecurity,
     StreamSettings, StreamTransport, TargetAddr, VlessOutboundSettings, VlessUser,
 };
+use xray_routing::Cidr;
 
-fn dns_filter_matches(filter: &DnsIpFilter, ip: IpAddr) -> bool {
-    compile_ip_matchers(&filter.custom_matchers).matches(ip)
-        || compile_ip_matchers(&filter.geoip_matchers).matches(ip)
+fn cidr(network: IpAddr, prefix_len: u8) -> Cidr {
+    Cidr::new(network, prefix_len).unwrap()
 }
 
 #[test]
@@ -324,10 +324,12 @@ fn normalized_model_can_represent_ip_routing_rule() {
             networks: Vec::new(),
             port_ranges: Vec::new(),
             domain_matchers: Vec::new(),
-            ip_matchers: compile_ip_matchers(&[
-                IpMatcher::Cidr(IpCidr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8).unwrap()),
-                IpMatcher::Private,
-            ]),
+            ip_matchers: {
+                let mut matchers = IpMatcherSet::builder();
+                matchers.insert_cidr(cidr(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8), false);
+                matchers.insert_private_networks(false);
+                matchers.build()
+            },
             outbound_tag: "direct".to_owned(),
         }],
         ..Default::default()
@@ -348,17 +350,13 @@ fn normalized_model_applies_inverse_ip_matchers_as_a_conjunction() {
             networks: Vec::new(),
             port_ranges: Vec::new(),
             domain_matchers: Vec::new(),
-            ip_matchers: compile_ip_matchers(&[
-                IpMatcher::Not(Box::new(IpMatcher::Cidr(
-                    IpCidr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8).unwrap(),
-                ))),
-                IpMatcher::Not(Box::new(IpMatcher::Cidr(
-                    IpCidr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 0)), 16).unwrap(),
-                ))),
-                IpMatcher::Cidr(
-                    IpCidr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 0)), 24).unwrap(),
-                ),
-            ]),
+            ip_matchers: {
+                let mut matchers = IpMatcherSet::builder();
+                matchers.insert_cidr(cidr(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8), true);
+                matchers.insert_cidr(cidr(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 0)), 16), true);
+                matchers.insert_cidr(cidr(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 0)), 24), false);
+                matchers.build()
+            },
             outbound_tag: "direct".to_owned(),
         }],
         ..Default::default()
@@ -372,52 +370,33 @@ fn normalized_model_applies_inverse_ip_matchers_as_a_conjunction() {
 
 #[test]
 fn dns_ip_filter_keeps_custom_and_geoip_inverse_unions_separate() {
-    let filter = DnsIpFilter {
-        custom_matchers: vec![IpMatcher::Not(Box::new(IpMatcher::Cidr(
-            IpCidr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8).unwrap(),
-        )))],
-        geoip_matchers: vec![IpMatcher::Not(Box::new(IpMatcher::Cidr(
-            IpCidr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 16).unwrap(),
-        )))],
-        soft: false,
-    };
+    let mut builder = DnsIpFilter::builder();
+    builder
+        .custom()
+        .insert_cidr(cidr(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 8), true);
+    builder
+        .geoip()
+        .insert_cidr(cidr(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)), 16), true);
+    let filter = builder.build();
 
-    assert!(!dns_filter_matches(
-        &filter,
-        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1))
-    ));
-    assert!(dns_filter_matches(
-        &filter,
-        IpAddr::V4(Ipv4Addr::new(10, 42, 1, 1))
-    ));
-    assert!(dns_filter_matches(
-        &filter,
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-    ));
+    assert!(!filter.is_soft());
+    assert_eq!(filter.matcher_count(), 2);
+    assert!(!filter.matches(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1))));
+    assert!(filter.matches(IpAddr::V4(Ipv4Addr::new(10, 42, 1, 1))));
+    assert!(filter.matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
 }
 
 #[test]
 fn dns_ip_filter_scopes_inverse_matchers_by_address_family() {
-    let filter = DnsIpFilter {
-        custom_matchers: vec![IpMatcher::Not(Box::new(IpMatcher::Cidr(
-            IpCidr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)), 24).unwrap(),
-        )))],
-        geoip_matchers: Vec::new(),
-        soft: false,
-    };
+    let mut builder = DnsIpFilter::builder();
+    builder
+        .custom()
+        .insert_cidr(cidr(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)), 24), true);
+    let filter = builder.build();
 
-    assert!(dns_filter_matches(
-        &filter,
-        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))
-    ));
-    assert!(!dns_filter_matches(
-        &filter,
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-    ));
-    assert!(!dns_filter_matches(
-        &filter,
-        IpAddr::V6(Ipv6Addr::LOCALHOST)
-    ));
+    assert!(filter.matches(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
+    assert!(!filter.matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
+    assert!(!filter.matches(IpAddr::V6(Ipv6Addr::LOCALHOST)));
 }
 
 #[test]
@@ -427,14 +406,9 @@ fn ip_cidr_canonicalizes_ipv4_mapped_ipv6_addresses() {
 
     assert_eq!(cidr.network(), IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)));
     assert_eq!(cidr.prefix(), 24);
-    assert!(dns_filter_matches(
-        &DnsIpFilter {
-            custom_matchers: vec![IpMatcher::Cidr(cidr)],
-            geoip_matchers: Vec::new(),
-            soft: false,
-        },
-        mapped,
-    ));
+    let mut builder = DnsIpFilter::builder();
+    builder.custom().insert_cidr(cidr.cidr(), false);
+    assert!(builder.build().matches(mapped));
     assert_eq!(
         IpCidr::new(mapped, 120).unwrap_err(),
         xray_config::ConfigModelError::InvalidCidrPrefix {

--- a/crates/xray-config/tests/parser_tests.rs
+++ b/crates/xray-config/tests/parser_tests.rs
@@ -7,20 +7,15 @@ use std::{
 
 use prost::Message;
 use xray_config::{
-    compile_ip_matchers, parse_xray_json, parse_xray_json_with_geodata_dirs, DiagnosticSeverity,
-    DnsFakeIpConfig, DnsHostTarget, DnsIpFilter, DnsNameServerConfig, DnsOutboundRuleAction,
-    DnsOutboundSettings, DnsQueryStrategy, DnsServerConfig, DnsServerEndpoint, DnsServerTransport,
+    parse_xray_json, parse_xray_json_with_geodata_dirs, DiagnosticSeverity, DnsFakeIpConfig,
+    DnsHostTarget, DnsIpFilter, DnsNameServerConfig, DnsOutboundRuleAction, DnsOutboundSettings,
+    DnsQueryStrategy, DnsServerConfig, DnsServerEndpoint, DnsServerTransport,
     HappyEyeballsSettings, InboundProtocol, IpCidr, Network, OutboundSettings, QuicBbrProfile,
     QuicCongestion, QuicIntervalRange, QuicParamsSettings, QuicUdpHopSettings, RealityShortId,
     RoutingDomainStrategy, SniffingDestination, StreamSecurity, StreamTransport, TargetAddr,
     XhttpMode, XhttpPaddingMethod, XhttpPaddingPlacement, XhttpPlacement, XhttpRange,
     XhttpSettings, XhttpUplinkDataPlacement,
 };
-
-fn dns_filter_matches(filter: &DnsIpFilter, ip: IpAddr) -> bool {
-    compile_ip_matchers(&filter.custom_matchers).matches(ip)
-        || compile_ip_matchers(&filter.geoip_matchers).matches(ip)
-}
 
 #[test]
 fn parses_vless_reality_vision_subset() {
@@ -2089,7 +2084,7 @@ fn parses_tcp_dns_string_shorthand_as_default_policy() {
     let parsed = parse_xray_json(&raw).expect("TCP DNS shorthand should parse");
     assert_eq!(
         parsed.config.dns.servers,
-        [DnsServerConfig::Policy(DnsNameServerConfig {
+        [DnsServerConfig::Policy(Box::new(DnsNameServerConfig {
             endpoint: DnsServerEndpoint::Ip(SocketAddr::from(([192, 0, 2, 53], 53))),
             transport: DnsServerTransport::TcpRouted,
             domains: Vec::new(),
@@ -2100,7 +2095,7 @@ fn parses_tcp_dns_string_shorthand_as_default_policy() {
             skip_fallback: false,
             query_strategy: DnsQueryStrategy::UseIp,
             final_query: false,
-        })]
+        }))]
     );
 }
 
@@ -2313,8 +2308,8 @@ fn parses_xray_dns_server_objects_and_fallback_policy() {
         panic!("expected policy DNS server");
     };
     assert_eq!(
-        second,
-        &DnsNameServerConfig {
+        **second,
+        DnsNameServerConfig {
             endpoint: DnsServerEndpoint::Domain {
                 domain: "dns.example".to_owned(),
                 port: 53,
@@ -2412,29 +2407,24 @@ fn parses_xray_dns_ip_filter_string_lists_and_soft_markers() {
         panic!("expected policy DNS server");
     };
 
-    assert!(server.expected_ips.soft);
-    assert_eq!(server.expected_ips.custom_matchers.len(), 2);
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-    ));
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))
-    ));
-    assert!(!dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))
-    ));
-    assert!(server.unexpected_ips.soft);
-    assert!(dns_filter_matches(
-        &server.unexpected_ips,
-        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
-    ));
-    assert!(!dns_filter_matches(
-        &server.unexpected_ips,
-        IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))
-    ));
+    assert!(server.expected_ips.is_soft());
+    assert_eq!(server.expected_ips.matcher_count(), 2);
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))));
+    assert!(!server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
+    assert!(server.unexpected_ips.is_soft());
+    assert!(server
+        .unexpected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+    assert!(!server
+        .unexpected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
 }
 
 #[test]
@@ -2450,10 +2440,9 @@ fn dns_ip_filters_canonicalize_ipv4_mapped_literals_like_xray() {
     let DnsServerConfig::Policy(server) = &parsed.config.dns.servers[0] else {
         panic!("expected policy DNS server");
     };
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-    ));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
 
     let invalid = raw_with_dns_servers(
         r#"{
@@ -2478,19 +2467,16 @@ fn dns_ip_filters_accept_xray_address_whitespace_brackets_and_empty_prefix() {
         panic!("expected policy DNS server");
     };
 
-    assert_eq!(server.expected_ips.custom_matchers.len(), 3);
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-    ));
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))
-    ));
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V6("2001:db8::1".parse().unwrap())
-    ));
+    assert_eq!(server.expected_ips.matcher_count(), 3);
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V6("2001:db8::1".parse().unwrap())));
 }
 
 #[test]
@@ -2508,10 +2494,9 @@ fn uses_expect_ips_alias_only_when_expected_ips_is_empty() {
         panic!("expected policy DNS server");
     };
 
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-    ));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
 }
 
 #[test]
@@ -2533,10 +2518,9 @@ fn treats_null_dns_ip_string_lists_as_empty() {
         panic!("expected policy DNS server");
     };
 
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-    ));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
     assert!(server.unexpected_ips.is_empty());
     let DnsServerConfig::Policy(server_with_null_alias) = &parsed.config.dns.servers[1] else {
         panic!("expected policy DNS server");
@@ -2559,7 +2543,7 @@ fn nonempty_expected_ips_wins_without_parsing_expect_ips_rules() {
         panic!("expected policy DNS server");
     };
 
-    assert!(server.expected_ips.soft);
+    assert!(server.expected_ips.is_soft());
     assert!(server.expected_ips.is_empty());
 }
 
@@ -2597,22 +2581,18 @@ fn parses_dns_geoip_ext_rules_and_repeated_inverse_prefixes() {
     let DnsServerConfig::Policy(server) = &parsed.config.dns.servers[0] else {
         panic!("expected policy DNS server");
     };
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))
-    ));
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))
-    ));
-    assert!(dns_filter_matches(
-        &server.unexpected_ips,
-        IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))
-    ));
-    assert!(!dns_filter_matches(
-        &server.unexpected_ips,
-        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))
-    ));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
+    assert!(server
+        .unexpected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+    assert!(!server
+        .unexpected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
 
     fs::remove_dir_all(asset_dir).unwrap();
 }
@@ -2654,8 +2634,8 @@ fn dns_ip_filters_ignore_geoip_asset_reverse_flag() {
     let inside = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
     let outside = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1));
 
-    assert!(dns_filter_matches(&server.expected_ips, inside));
-    assert!(!dns_filter_matches(&server.expected_ips, outside));
+    assert!(server.expected_ips.matches(inside));
+    assert!(!server.expected_ips.matches(outside));
     assert!(!parsed.config.routing.rules[0].matches_ip(Some(&inside)));
     assert!(parsed.config.routing.rules[0].matches_ip(Some(&outside)));
 
@@ -2687,14 +2667,12 @@ fn dns_geoip_private_uses_the_configured_xray_asset() {
         panic!("expected policy DNS server");
     };
 
-    assert!(dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))
-    ));
-    assert!(!dns_filter_matches(
-        &server.expected_ips,
-        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))
-    ));
+    assert!(server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))));
+    assert!(!server
+        .expected_ips
+        .matches(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
 
     fs::remove_dir_all(asset_dir).unwrap();
 }

--- a/crates/xray-core-rs/src/dns.rs
+++ b/crates/xray-core-rs/src/dns.rs
@@ -882,16 +882,22 @@ mod tests {
     use tokio::sync::oneshot;
     use tokio_rustls::TlsAcceptor;
     use xray_config::{
-        compile_ip_matchers, CoreConfig, DnsConfig, DnsHostMapping, DnsHostTarget, DnsOutboundRule,
+        CoreConfig, DnsConfig, DnsHostMapping, DnsHostTarget, DnsOutboundRule,
         DnsOutboundRuleAction, DnsOutboundSettings, DnsQTypeRange, DnsServerConfig, DomainMatcher,
-        IpCidr, IpMatcher, Network, OutboundConfig, OutboundSettings, PolicyConfig, RoutingConfig,
-        RoutingDomainStrategy, RoutingRule, StreamSecurity, StreamSettings, StreamTransport,
-        TargetAddr as ConfigTargetAddr, TlsSettings,
+        IpCidr, IpMatcherSet, Network, OutboundConfig, OutboundSettings, PolicyConfig,
+        RoutingConfig, RoutingDomainStrategy, RoutingRule, StreamSecurity, StreamSettings,
+        StreamTransport, TargetAddr as ConfigTargetAddr, TlsSettings,
     };
     use xray_transport::{
         DnsQueryMetadata, DnsQueryTransportKind, SocketHandle, SocketProtector, TlsConnector,
         TransportError,
     };
+
+    fn ip_matcher_set(cidr: IpCidr) -> IpMatcherSet {
+        let mut matchers = IpMatcherSet::builder();
+        matchers.insert_cidr(cidr.cidr(), false);
+        matchers.build()
+    }
 
     use super::*;
     use crate::dns_outbound_runtime::{
@@ -1045,9 +1051,9 @@ mod tests {
                     networks: vec![network],
                     port_ranges: Vec::new(),
                     domain_matchers: Vec::new(),
-                    ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
+                    ip_matchers: ip_matcher_set(
                         IpCidr::new(server.ip(), if server.is_ipv4() { 32 } else { 128 }).unwrap(),
-                    )]),
+                    ),
                     outbound_tag: "dns-out".to_owned(),
                 }],
                 domain_strategy: RoutingDomainStrategy::IpIfNonMatch,

--- a/crates/xray-core-rs/src/lib.rs
+++ b/crates/xray-core-rs/src/lib.rs
@@ -9,15 +9,13 @@ use thiserror::Error;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use xray_config::{
-    CoreConfig, DnsHostTarget, DnsIpFilter as ConfigDnsIpFilter,
-    DnsQueryStrategy as ConfigDnsQueryStrategy, DnsServerConfig, DnsServerEndpoint,
-    DnsServerTransport as ConfigDnsServerTransport, DomainMatcher, InboundProtocol,
-    IpMatcher as ConfigIpMatcher,
+    CoreConfig, DnsHostTarget, DnsIpFilter, DnsQueryStrategy as ConfigDnsQueryStrategy,
+    DnsServerConfig, DnsServerEndpoint, DnsServerTransport as ConfigDnsServerTransport,
+    DomainMatcher, InboundProtocol,
 };
 use xray_runtime::Shutdown;
 use xray_transport::{
     CachingDnsResolver, CompiledNameServerPolicies, ConfiguredDnsResolver,
-    DnsIpFilter as TransportDnsIpFilter, DnsIpMatcher as TransportDnsIpMatcher,
     DnsQueryStrategy as TransportDnsQueryStrategy, DnsQueryTransport, DnsResolver, NameServer,
     NameServerPolicy, NameServerTransport, SocketProtector, StaticHostRule, StaticHostTarget,
     SystemDnsResolver, TransportDialer, TransportDomainMatcher, TransportError,
@@ -894,11 +892,9 @@ fn take_name_server_policy_set(config: &mut CoreConfig) -> Arc<CompiledNameServe
                     std::mem::take(&mut policy.expected_ips),
                     std::mem::take(&mut policy.unexpected_ips),
                 ),
-                DnsServerConfig::Ip(_) | DnsServerConfig::Domain { .. } => (
-                    Vec::new(),
-                    ConfigDnsIpFilter::default(),
-                    ConfigDnsIpFilter::default(),
-                ),
+                DnsServerConfig::Ip(_) | DnsServerConfig::Domain { .. } => {
+                    (Vec::new(), DnsIpFilter::default(), DnsIpFilter::default())
+                }
             };
             Some(NameServerPolicy {
                 server: name_server,
@@ -908,8 +904,8 @@ fn take_name_server_policy_set(config: &mut CoreConfig) -> Arc<CompiledNameServe
                     .into_iter()
                     .map(into_transport_domain_matcher)
                     .collect(),
-                expected_ips: into_transport_dns_ip_filter(expected_ips),
-                unexpected_ips: into_transport_dns_ip_filter(unexpected_ips),
+                expected_ips,
+                unexpected_ips,
                 timeout,
                 skip_fallback,
                 query_strategy,
@@ -1083,33 +1079,6 @@ fn into_transport_domain_matcher(matcher: DomainMatcher) -> TransportDomainMatch
     }
 }
 
-fn into_transport_dns_ip_filter(filter: ConfigDnsIpFilter) -> TransportDnsIpFilter {
-    TransportDnsIpFilter {
-        custom_matchers: filter
-            .custom_matchers
-            .into_iter()
-            .map(into_transport_dns_ip_matcher)
-            .collect(),
-        geoip_matchers: filter
-            .geoip_matchers
-            .into_iter()
-            .map(into_transport_dns_ip_matcher)
-            .collect(),
-        soft: filter.soft,
-    }
-}
-
-fn into_transport_dns_ip_matcher(matcher: ConfigIpMatcher) -> TransportDnsIpMatcher {
-    match matcher {
-        ConfigIpMatcher::Cidr(cidr) => TransportDnsIpMatcher::cidr(cidr.network(), cidr.prefix())
-            .expect("xray-config DNS IP matcher should contain a prevalidated CIDR"),
-        ConfigIpMatcher::Private => TransportDnsIpMatcher::Private,
-        ConfigIpMatcher::Not(matcher) => {
-            TransportDnsIpMatcher::Not(Box::new(into_transport_dns_ip_matcher(*matcher)))
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::io;
@@ -1128,9 +1097,9 @@ mod tests {
 
     use super::{
         configured_dns_resolver_for_config, configured_dns_resolver_from_config_with_transport,
-        host_only_dns_resolver_for_config, into_transport_dns_ip_filter,
-        static_only_dns_resolver_for_config, take_name_server_policy_set, Core, DnsRuntimeLimits,
-        TransportDnsQueryStrategy, TunRuntimeOptions, TunRuntimeProfile,
+        host_only_dns_resolver_for_config, static_only_dns_resolver_for_config,
+        take_name_server_policy_set, Core, DnsRuntimeLimits, TransportDnsQueryStrategy,
+        TunRuntimeOptions, TunRuntimeProfile,
     };
 
     struct StaticResolver;
@@ -1450,31 +1419,6 @@ mod tests {
                 ),
             ]
         );
-    }
-
-    #[test]
-    fn dns_ip_filter_conversion_preserves_categories_inverse_and_soft_mode() {
-        let config_filter = xray_config::DnsIpFilter {
-            custom_matchers: vec![xray_config::IpMatcher::Cidr(
-                xray_config::IpCidr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)), 24).unwrap(),
-            )],
-            geoip_matchers: vec![xray_config::IpMatcher::Not(Box::new(
-                xray_config::IpMatcher::Cidr(
-                    xray_config::IpCidr::new(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 0)), 24)
-                        .unwrap(),
-                ),
-            ))],
-            soft: true,
-        };
-
-        let filter =
-            xray_transport::CompiledDnsIpFilter::new(into_transport_dns_ip_filter(config_filter));
-
-        assert!(filter.is_soft());
-        assert_eq!(filter.matcher_count(), 2);
-        assert!(filter.matches(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))));
-        assert!(filter.matches(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))));
-        assert!(!filter.matches(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1))));
     }
 
     #[test]

--- a/crates/xray-core-rs/src/outbound.rs
+++ b/crates/xray-core-rs/src/outbound.rs
@@ -2445,10 +2445,10 @@ mod tests {
     use tokio::net::TcpListener;
     use uuid::Uuid;
     use xray_config::{
-        compile_ip_matchers, DnsConfig, DnsServerConfig, DomainMatcher, GrpcSettings,
-        HappyEyeballsSettings, HttpUpgradeSettings, IpCidr, IpMatcher, RealitySettings,
-        RealityShortId, RoutingConfig, RoutingDomainStrategy, RoutingPortRange, RoutingRule,
-        SocketOptions, StreamSettings, TlsSettings, VlessOutboundSettings, WebSocketSettings,
+        DnsConfig, DnsServerConfig, DomainMatcher, GrpcSettings, HappyEyeballsSettings,
+        HttpUpgradeSettings, IpCidr, IpMatcherSet, RealitySettings, RealityShortId, RoutingConfig,
+        RoutingDomainStrategy, RoutingPortRange, RoutingRule, SocketOptions, StreamSettings,
+        TlsSettings, VlessOutboundSettings, WebSocketSettings,
     };
     use xray_proxy::vless::{unpad_vision_block, VisionCommand};
     use xray_transport::{CachingDnsResolver, DnsLookup, RealityTlsEngine, TransportError};
@@ -2643,13 +2643,19 @@ mod tests {
         )
     }
 
+    fn ip_matcher_set(cidr: IpCidr) -> IpMatcherSet {
+        let mut matchers = IpMatcherSet::builder();
+        matchers.insert_cidr(cidr.cidr(), false);
+        matchers.build()
+    }
+
     fn ip_rule(tag: &str, ip: Ipv4Addr) -> RoutingRule {
         RoutingRule {
             inbound_tags: Vec::new(),
             networks: Vec::new(),
             port_ranges: Vec::new(),
             domain_matchers: Vec::new(),
-            ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(IpCidr::full(IpAddr::V4(ip)))]),
+            ip_matchers: ip_matcher_set(IpCidr::full(IpAddr::V4(ip))),
             outbound_tag: tag.to_owned(),
         }
     }
@@ -2660,7 +2666,7 @@ mod tests {
             networks: Vec::new(),
             port_ranges: Vec::new(),
             domain_matchers: vec![DomainMatcher::Full(domain.to_owned())],
-            ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(IpCidr::full(IpAddr::V4(ip)))]),
+            ip_matchers: ip_matcher_set(IpCidr::full(IpAddr::V4(ip))),
             outbound_tag: tag.to_owned(),
         }
     }

--- a/crates/xray-core-rs/src/tun_dns.rs
+++ b/crates/xray-core-rs/src/tun_dns.rs
@@ -5964,7 +5964,7 @@ mod tests {
                     domain: "Resolver.Example".to_owned(),
                     port: 53,
                 },
-                DnsServerConfig::Policy(xray_config::DnsNameServerConfig {
+                DnsServerConfig::Policy(Box::new(xray_config::DnsNameServerConfig {
                     endpoint: xray_config::DnsServerEndpoint::Domain {
                         domain: "policy.example.".to_owned(),
                         port: 5_353,
@@ -5980,7 +5980,7 @@ mod tests {
                     skip_fallback: true,
                     query_strategy: xray_config::DnsQueryStrategy::UseIpv6,
                     final_query: true,
-                }),
+                })),
                 DnsServerConfig::Ip(first),
                 DnsServerConfig::Ip(first),
                 DnsServerConfig::Ip(SocketAddr::from((Ipv4Addr::new(9, 9, 9, 9), 0))),

--- a/crates/xray-core-rs/tests/runtime_data_path_tests.rs
+++ b/crates/xray-core-rs/tests/runtime_data_path_tests.rs
@@ -42,11 +42,11 @@ use tokio::time::{sleep, timeout, Duration, Instant as TokioInstant};
 use tokio_rustls::TlsAcceptor;
 use uuid::Uuid;
 use xray_config::{
-    compile_ip_matchers, parse_xray_json, CoreConfig, DnsConfig, DnsFakeIpConfig, DnsHostMapping,
-    DnsHostTarget, DnsNameServerConfig, DnsOutboundRule, DnsOutboundRuleAction,
-    DnsOutboundSettings, DnsQTypeRange, DnsQueryStrategy, DnsServerConfig, DnsServerEndpoint,
-    DomainMatcher, InboundConfig, InboundProtocol, InboundSniffingConfig, IpCidr, IpMatcher,
-    Network, OutboundConfig, OutboundSettings, PolicyConfig, PolicyLevelConfig, RealitySettings,
+    parse_xray_json, CoreConfig, DnsConfig, DnsFakeIpConfig, DnsHostMapping, DnsHostTarget,
+    DnsNameServerConfig, DnsOutboundRule, DnsOutboundRuleAction, DnsOutboundSettings,
+    DnsQTypeRange, DnsQueryStrategy, DnsServerConfig, DnsServerEndpoint, DomainMatcher,
+    InboundConfig, InboundProtocol, InboundSniffingConfig, IpCidr, IpMatcherSet, Network,
+    OutboundConfig, OutboundSettings, PolicyConfig, PolicyLevelConfig, RealitySettings,
     RealityShortId, RoutingConfig, RoutingDomainStrategy, RoutingPortRange, RoutingRule,
     SniffingDestination, StreamSecurity, StreamSettings, StreamTransport, TargetAddr, TlsSettings,
     VlessOutboundSettings, VlessUser,
@@ -66,6 +66,12 @@ use xray_transport::{
     TransportDialer, TransportError, TransportStream,
 };
 use xray_tun::{TunEndpoint, TunError, TunStats};
+
+fn ip_matcher_set(cidr: IpCidr) -> IpMatcherSet {
+    let mut matchers = IpMatcherSet::builder();
+    matchers.insert_cidr(cidr.cidr(), false);
+    matchers.build()
+}
 
 const ICMPV4_PROTOCOL: u8 = 1;
 const ICMPV6_PROTOCOL: u8 = 58;
@@ -145,7 +151,7 @@ fn tagged_dns_server_with_transport(
     tag: &str,
     transport: xray_config::DnsServerTransport,
 ) -> DnsServerConfig {
-    DnsServerConfig::Policy(DnsNameServerConfig {
+    DnsServerConfig::Policy(Box::new(DnsNameServerConfig {
         endpoint,
         transport,
         domains: Vec::new(),
@@ -156,7 +162,7 @@ fn tagged_dns_server_with_transport(
         skip_fallback: false,
         query_strategy: DnsQueryStrategy::UseIp,
         final_query: false,
-    })
+    }))
 }
 
 fn config_with_outbound(outbound: OutboundConfig) -> CoreConfig {
@@ -608,9 +614,7 @@ fn runtime_tun_dns_proxy_config_routing_second_upstream_to_freedom(
         networks: Vec::new(),
         port_ranges: Vec::new(),
         domain_matchers: Vec::new(),
-        ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
-            IpCidr::new(second.ip(), prefix).unwrap(),
-        )]),
+        ip_matchers: ip_matcher_set(IpCidr::new(second.ip(), prefix).unwrap()),
         outbound_tag: "direct".to_owned(),
     }];
     config.dns.tag = "dns-global".to_owned();
@@ -625,9 +629,8 @@ fn runtime_tun_config_with_fake_ip_ip_if_non_match_routed_freedom_outbound(
     unused_proxy_port: u16,
 ) -> CoreConfig {
     let mut config = runtime_tun_config_with_routed_freedom_outbound(unused_proxy_port);
-    config.routing.rules[0].ip_matchers = compile_ip_matchers(&[IpMatcher::Cidr(
-        IpCidr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)), 8).unwrap(),
-    )]);
+    config.routing.rules[0].ip_matchers =
+        ip_matcher_set(IpCidr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)), 8).unwrap());
     config.routing.domain_strategy = RoutingDomainStrategy::IpIfNonMatch;
     config.dns = DnsConfig {
         fake_ip: Some(DnsFakeIpConfig {
@@ -904,9 +907,9 @@ fn runtime_config_with_ip_routed_freedom_outbound(unused_proxy_port: u16) -> Cor
                 networks: Vec::new(),
                 port_ranges: Vec::new(),
                 domain_matchers: Vec::new(),
-                ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
+                ip_matchers: ip_matcher_set(
                     IpCidr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)), 8).unwrap(),
-                )]),
+                ),
                 outbound_tag: "direct".to_owned(),
             }],
             ..Default::default()
@@ -946,9 +949,9 @@ fn runtime_config_with_ip_if_non_match_routed_freedom_outbound(
                 networks: Vec::new(),
                 port_ranges: Vec::new(),
                 domain_matchers: Vec::new(),
-                ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
+                ip_matchers: ip_matcher_set(
                     IpCidr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0)), 8).unwrap(),
-                )]),
+                ),
                 outbound_tag: "direct".to_owned(),
             }],
             domain_strategy: RoutingDomainStrategy::IpIfNonMatch,
@@ -5325,7 +5328,7 @@ async fn run_core_wide_fake_dns_socks_to_http_scenario() {
         networks: vec![Network::Tcp],
         port_ranges: Vec::new(),
         domain_matchers: Vec::new(),
-        ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(fake_ip_pool)]),
+        ip_matchers: ip_matcher_set(fake_ip_pool),
         outbound_tag: "dns-out".to_owned(),
     });
     config.routing.rules.push(RoutingRule {
@@ -5333,7 +5336,7 @@ async fn run_core_wide_fake_dns_socks_to_http_scenario() {
         networks: vec![Network::Udp],
         port_ranges: Vec::new(),
         domain_matchers: Vec::new(),
-        ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(fake_ip_pool)]),
+        ip_matchers: ip_matcher_set(fake_ip_pool),
         outbound_tag: "dns-out".to_owned(),
     });
     config.dns.fake_ip = Some(DnsFakeIpConfig {
@@ -5443,9 +5446,9 @@ async fn run_tun_dns_outbound_fake_ip_domain_scenario() {
         networks: vec![Network::Udp],
         port_ranges: vec![RoutingPortRange::single(upstream.port())],
         domain_matchers: Vec::new(),
-        ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
+        ip_matchers: ip_matcher_set(
             IpCidr::new(upstream.ip(), if upstream.is_ipv4() { 32 } else { 128 }).unwrap(),
-        )]),
+        ),
         outbound_tag: "dns-out".to_owned(),
     }];
     config.routing.domain_strategy = RoutingDomainStrategy::IpIfNonMatch;
@@ -5518,9 +5521,9 @@ async fn run_tun_dns_outbound_tcp_fake_ip_domain_scenario() {
         networks: vec![Network::Tcp],
         port_ranges: vec![RoutingPortRange::single(upstream.port())],
         domain_matchers: Vec::new(),
-        ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
+        ip_matchers: ip_matcher_set(
             IpCidr::new(upstream.ip(), if upstream.is_ipv4() { 32 } else { 128 }).unwrap(),
-        )]),
+        ),
         outbound_tag: "dns-out".to_owned(),
     }];
     config.routing.domain_strategy = RoutingDomainStrategy::IpIfNonMatch;
@@ -5616,7 +5619,7 @@ async fn run_tun_dns_hijack_udp_matched_policy_scenario() {
     config.dns.disable_fallback_if_match = true;
     config.dns.servers = vec![
         DnsServerConfig::Ip(default.addr()),
-        DnsServerConfig::Policy(DnsNameServerConfig {
+        DnsServerConfig::Policy(Box::new(DnsNameServerConfig {
             endpoint: DnsServerEndpoint::Ip(matched.addr()),
             transport: xray_config::DnsServerTransport::Classic,
             domains: vec![DomainMatcher::Full(domain.to_owned())],
@@ -5627,7 +5630,7 @@ async fn run_tun_dns_hijack_udp_matched_policy_scenario() {
             skip_fallback: false,
             query_strategy: DnsQueryStrategy::UseIp,
             final_query: false,
-        }),
+        })),
     ];
     let mut core = Core::new(config).unwrap();
     core.start().await.unwrap();
@@ -6613,9 +6616,9 @@ async fn run_tun_dns_proxy_udp_static_ip_skip_routing_scenario() {
         networks: Vec::new(),
         port_ranges: Vec::new(),
         domain_matchers: Vec::new(),
-        ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
+        ip_matchers: ip_matcher_set(
             IpCidr::new(upstream.ip(), if upstream.is_ipv4() { 32 } else { 128 }).unwrap(),
-        )]),
+        ),
         outbound_tag: "proxy".to_owned(),
     }];
     config.dns.tag = "dns-route".to_owned();
@@ -6682,9 +6685,9 @@ async fn run_tun_dns_proxy_udp_dynamic_ip_skip_routing_scenario() {
         networks: Vec::new(),
         port_ranges: Vec::new(),
         domain_matchers: Vec::new(),
-        ip_matchers: compile_ip_matchers(&[IpMatcher::Cidr(
+        ip_matchers: ip_matcher_set(
             IpCidr::new(upstream.ip(), if upstream.is_ipv4() { 32 } else { 128 }).unwrap(),
-        )]),
+        ),
         outbound_tag: "proxy".to_owned(),
     }];
     config.dns.tag = "dns-route".to_owned();
@@ -6999,7 +7002,7 @@ async fn run_tun_dns_hijack_tcp_mixed_pipeline_scenario() {
     let mut config = runtime_tun_config_with_freedom_outbound();
     config.dns.disable_fallback_if_match = true;
     config.dns.servers = vec![
-        DnsServerConfig::Policy(DnsNameServerConfig {
+        DnsServerConfig::Policy(Box::new(DnsNameServerConfig {
             endpoint: DnsServerEndpoint::Ip(hijack_upstream.addr()),
             transport: xray_config::DnsServerTransport::Classic,
             domains: vec![DomainMatcher::Full(domain.to_owned())],
@@ -7010,7 +7013,7 @@ async fn run_tun_dns_hijack_tcp_mixed_pipeline_scenario() {
             skip_fallback: false,
             query_strategy: DnsQueryStrategy::UseIp,
             final_query: false,
-        }),
+        })),
         DnsServerConfig::Ip(raw_server.addr()),
     ];
     let (mut core, mut client) = start_tun_dns_tcp_session_with_config(config).await;

--- a/crates/xray-routing/src/ip_filter.rs
+++ b/crates/xray-routing/src/ip_filter.rs
@@ -1,0 +1,298 @@
+use std::net::IpAddr;
+
+use crate::ip_range_set::{IpMatcherSet, IpMatcherSetBuilder};
+
+/// Query-ready `expectedIPs`/`unexpectedIPs` filter: custom and GeoIP matcher
+/// categories are independent Xray submatchers ORed together, `soft` is the
+/// `*` marker (the preferred subset is used only when it is non-empty).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DnsIpFilter {
+    custom: IpMatcherSet,
+    geoip: IpMatcherSet,
+    soft: bool,
+    matcher_count: usize,
+}
+
+impl DnsIpFilter {
+    pub fn builder() -> DnsIpFilterBuilder {
+        DnsIpFilterBuilder::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.custom.is_empty() && self.geoip.is_empty()
+    }
+
+    pub fn is_soft(&self) -> bool {
+        self.soft
+    }
+
+    /// Returns the number of source matcher entries supplied to the filter.
+    ///
+    /// `Private` counts as one source entry even though compilation expands it
+    /// into the nine Xray private-address networks. Inverting a matcher also
+    /// does not change the source count.
+    pub fn matcher_count(&self) -> usize {
+        self.matcher_count
+    }
+
+    /// Returns the deterministic number of merged ranges retained by the
+    /// query-time index across custom/GeoIP, positive/inverse, and IP-family
+    /// partitions.
+    pub fn compiled_range_count(&self) -> usize {
+        self.custom.range_count() + self.geoip.range_count()
+    }
+
+    pub fn matches(&self, address: IpAddr) -> bool {
+        self.custom.matches(address) || self.geoip.matches(address)
+    }
+
+    /// Applies this filter as `expectedIPs` and returns false when a hard
+    /// filter rejects every candidate.
+    pub fn apply_expected(&self, addresses: &mut Vec<IpAddr>) -> bool {
+        self.retain_preferred(addresses, true)
+    }
+
+    /// Applies this filter as `unexpectedIPs` and returns false when a hard
+    /// filter rejects every candidate.
+    pub fn apply_unexpected(&self, addresses: &mut Vec<IpAddr>) -> bool {
+        self.retain_preferred(addresses, false)
+    }
+
+    fn retain_preferred(&self, addresses: &mut Vec<IpAddr>, keep_matches: bool) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+        let preferred = |address: &IpAddr| self.matches(*address) == keep_matches;
+        if self.soft && !addresses.iter().any(&preferred) {
+            return true;
+        }
+        addresses.retain(preferred);
+        !addresses.is_empty()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DnsIpFilterBuilder {
+    custom: IpMatcherSetBuilder,
+    geoip: IpMatcherSetBuilder,
+    soft: bool,
+}
+
+impl DnsIpFilterBuilder {
+    pub fn custom(&mut self) -> &mut IpMatcherSetBuilder {
+        &mut self.custom
+    }
+
+    pub fn geoip(&mut self) -> &mut IpMatcherSetBuilder {
+        &mut self.geoip
+    }
+
+    pub fn set_soft(&mut self, soft: bool) {
+        self.soft = soft;
+    }
+
+    pub fn build(self) -> DnsIpFilter {
+        DnsIpFilter {
+            matcher_count: self.custom.matcher_count() + self.geoip.matcher_count(),
+            custom: self.custom.build(),
+            geoip: self.geoip.build(),
+            soft: self.soft,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+    use crate::ip_range_set::Cidr;
+
+    fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    fn v6(segments: [u16; 8]) -> IpAddr {
+        IpAddr::V6(Ipv6Addr::from(segments))
+    }
+
+    fn mapped(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V6(Ipv4Addr::new(a, b, c, d).to_ipv6_mapped())
+    }
+
+    fn cidr(network: IpAddr, prefix_len: u8) -> Cidr {
+        Cidr::new(network, prefix_len).unwrap()
+    }
+
+    fn filter(custom: &[(Cidr, bool)], geoip: &[(Cidr, bool)], soft: bool) -> DnsIpFilter {
+        let mut builder = DnsIpFilter::builder();
+        for (cidr, inverted) in custom {
+            builder.custom().insert_cidr(*cidr, *inverted);
+        }
+        for (cidr, inverted) in geoip {
+            builder.geoip().insert_cidr(*cidr, *inverted);
+        }
+        builder.set_soft(soft);
+        builder.build()
+    }
+
+    #[test]
+    fn filter_counts_source_matchers_and_merged_ranges_separately() {
+        let mut builder = DnsIpFilter::builder();
+        builder.custom().insert_private_networks(false);
+        let private = builder.build();
+        assert_eq!(private.matcher_count(), 1);
+        assert_eq!(private.compiled_range_count(), 9);
+        assert!(private.matches(v4(10, 1, 2, 3)));
+        assert!(private.matches(v6([0xfd00, 0, 0, 0, 0, 0, 0, 1])));
+        assert!(!private.matches(v4(8, 8, 8, 8)));
+
+        let merged = filter(
+            &[
+                (cidr(v4(192, 0, 2, 0), 25), false),
+                (cidr(v4(192, 0, 2, 128), 25), false),
+            ],
+            &[(cidr(v4(10, 0, 0, 0), 8), true)],
+            false,
+        );
+        assert_eq!(merged.matcher_count(), 3);
+        assert_eq!(merged.compiled_range_count(), 2);
+        assert!(merged.matches(v4(192, 0, 2, 255)));
+
+        let mut builder = DnsIpFilter::builder();
+        builder.geoip().insert_ip(v4(198, 51, 100, 1), false);
+        builder.geoip().insert_ip(mapped(198, 51, 100, 2), false);
+        let hosts = builder.build();
+        assert_eq!(hosts.matcher_count(), 2);
+        assert_eq!(hosts.compiled_range_count(), 1);
+        assert!(hosts.matches(v4(198, 51, 100, 2)));
+        assert!(!hosts.matches(v4(198, 51, 100, 3)));
+    }
+
+    #[test]
+    fn filter_ors_custom_and_geoip_categories_independently() {
+        let positive = filter(
+            &[(cidr(v4(192, 0, 2, 0), 24), false)],
+            &[(cidr(v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 0]), 32), false)],
+            false,
+        );
+        assert!(positive.matches(v4(192, 0, 2, 10)));
+        assert!(positive.matches(mapped(192, 0, 2, 10)));
+        assert!(positive.matches(v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 10])));
+        assert!(!positive.matches(v4(198, 51, 100, 10)));
+
+        let inverse = filter(
+            &[(cidr(v4(10, 0, 0, 0), 8), true)],
+            &[(cidr(v4(10, 0, 0, 0), 16), true)],
+            false,
+        );
+        assert!(!inverse.matches(v4(10, 0, 1, 1)));
+        assert!(inverse.matches(v4(10, 42, 1, 1)));
+        assert!(inverse.matches(v4(192, 0, 2, 1)));
+        assert!(!inverse.matches(v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 1])));
+
+        let disjoint_inverse = filter(
+            &[(cidr(v4(10, 0, 0, 0), 8), true)],
+            &[(cidr(v4(192, 168, 0, 0), 16), true)],
+            false,
+        );
+        assert!(disjoint_inverse.matches(v4(10, 1, 2, 3)));
+        assert!(disjoint_inverse.matches(v4(192, 168, 1, 2)));
+        assert!(disjoint_inverse.matches(v4(203, 0, 113, 7)));
+        assert!(!disjoint_inverse.matches(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+
+        let mixed = filter(
+            &[(cidr(v4(192, 0, 2, 0), 24), false)],
+            &[(cidr(v4(198, 51, 100, 0), 24), true)],
+            true,
+        );
+        assert!(mixed.is_soft());
+        assert_eq!(mixed.matcher_count(), 2);
+        assert!(mixed.matches(v4(192, 0, 2, 1)));
+        assert!(mixed.matches(v4(203, 0, 113, 1)));
+        assert!(!mixed.matches(v4(198, 51, 100, 1)));
+    }
+
+    #[test]
+    fn filter_applies_expected_with_hard_and_soft_semantics() {
+        let matching_v4 = v4(192, 0, 2, 10);
+        let matching_v6 = v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 10]);
+        let rejected = v4(198, 51, 100, 10);
+        let matchers = [
+            (cidr(v4(192, 0, 2, 0), 24), false),
+            (cidr(v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 0]), 32), false),
+        ];
+        let hard = filter(&matchers, &[], false);
+        let soft = filter(&matchers, &[], true);
+        assert!(!hard.is_soft());
+        assert!(soft.is_soft());
+
+        let mut hard_candidates = vec![matching_v6, rejected, matching_v4, matching_v6];
+        assert!(hard.apply_expected(&mut hard_candidates));
+        assert_eq!(hard_candidates, [matching_v6, matching_v4, matching_v6]);
+
+        let mut hard_rejected = vec![rejected];
+        assert!(!hard.apply_expected(&mut hard_rejected));
+        assert!(hard_rejected.is_empty());
+
+        let mut soft_preferred = vec![rejected, matching_v4];
+        assert!(soft.apply_expected(&mut soft_preferred));
+        assert_eq!(soft_preferred, [matching_v4]);
+
+        let mut soft_fallback = vec![rejected, rejected];
+        assert!(soft.apply_expected(&mut soft_fallback));
+        assert_eq!(soft_fallback, [rejected, rejected]);
+    }
+
+    #[test]
+    fn filter_applies_unexpected_with_hard_and_soft_semantics() {
+        let unexpected = v4(192, 0, 2, 10);
+        let preferred_v4 = v4(198, 51, 100, 10);
+        let preferred_v6 = v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 10]);
+        let matchers = [(cidr(v4(192, 0, 2, 0), 24), false)];
+        let hard = filter(&matchers, &[], false);
+        let soft = filter(&matchers, &[], true);
+
+        let mut hard_candidates = vec![unexpected, preferred_v4, preferred_v6, preferred_v4];
+        assert!(hard.apply_unexpected(&mut hard_candidates));
+        assert_eq!(hard_candidates, [preferred_v4, preferred_v6, preferred_v4]);
+
+        let mut hard_rejected = vec![unexpected, unexpected];
+        assert!(!hard.apply_unexpected(&mut hard_rejected));
+        assert!(hard_rejected.is_empty());
+
+        let mut soft_preferred = vec![unexpected, preferred_v4];
+        assert!(soft.apply_unexpected(&mut soft_preferred));
+        assert_eq!(soft_preferred, [preferred_v4]);
+
+        let mut soft_fallback = vec![unexpected, unexpected];
+        assert!(soft.apply_unexpected(&mut soft_fallback));
+        assert_eq!(soft_fallback, [unexpected, unexpected]);
+    }
+
+    #[test]
+    fn empty_filter_is_a_noop_even_when_hard() {
+        let empty = DnsIpFilter::default();
+        let original = vec![v4(192, 0, 2, 1)];
+        let mut expected = original.clone();
+        let mut unexpected = original.clone();
+
+        assert!(empty.is_empty());
+        assert!(!empty.is_soft());
+        assert_eq!(empty.matcher_count(), 0);
+        assert_eq!(empty.compiled_range_count(), 0);
+        assert!(!empty.matches(v4(192, 0, 2, 1)));
+        assert!(empty.apply_expected(&mut expected));
+        assert!(empty.apply_unexpected(&mut unexpected));
+        assert_eq!(expected, original);
+        assert_eq!(unexpected, original);
+        assert_eq!(DnsIpFilter::builder().build(), empty);
+
+        let mut builder = DnsIpFilter::builder();
+        builder.set_soft(true);
+        let soft_empty = builder.build();
+        assert!(soft_empty.is_empty());
+        assert!(soft_empty.is_soft());
+        assert_ne!(soft_empty, empty);
+    }
+}

--- a/crates/xray-routing/src/ip_range_set.rs
+++ b/crates/xray-routing/src/ip_range_set.rs
@@ -96,22 +96,6 @@ impl Cidr {
         }
     }
 
-    /// The same CIDR with the host bits below `prefix_len` cleared.
-    pub fn normalized(self) -> Self {
-        let network = match self.network {
-            IpAddr::V4(network) => IpAddr::V4(Ipv4Addr::from(
-                InclusiveRange::from_prefix(u32::from(network), self.prefix_len).start,
-            )),
-            IpAddr::V6(network) => IpAddr::V6(Ipv6Addr::from(
-                InclusiveRange::from_prefix(u128::from(network), self.prefix_len).start,
-            )),
-        };
-        Self {
-            network,
-            prefix_len: self.prefix_len,
-        }
-    }
-
     pub const fn network(self) -> IpAddr {
         self.network
     }
@@ -338,15 +322,26 @@ impl IpMatcherSet {
 pub struct IpMatcherSetBuilder {
     positive: IpRangeSetBuilder,
     inverse: IpRangeSetBuilder,
+    matcher_count: usize,
 }
 
 impl IpMatcherSetBuilder {
     pub fn insert_cidr(&mut self, cidr: Cidr, inverted: bool) {
         self.ranges(inverted).insert_cidr(cidr);
+        self.matcher_count += 1;
+    }
+
+    pub fn insert_ip(&mut self, address: IpAddr, inverted: bool) {
+        self.insert_cidr(Cidr::host(address), inverted);
     }
 
     pub fn insert_private_networks(&mut self, inverted: bool) {
         self.ranges(inverted).insert_private_networks();
+        self.matcher_count += 1;
+    }
+
+    pub fn matcher_count(&self) -> usize {
+        self.matcher_count
     }
 
     pub fn build(self) -> IpMatcherSet {
@@ -404,25 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn cidr_helpers_mask_host_bits_and_reject_mixed_families() {
-        assert_eq!(
-            cidr(v4(10, 1, 2, 3), 8).normalized().network(),
-            v4(10, 0, 0, 0)
-        );
-        assert_eq!(
-            cidr(mapped(10, 1, 2, 3), 16).normalized().network(),
-            v4(10, 1, 0, 0)
-        );
-        assert_eq!(
-            cidr(v6([0x2001, 0xdb8, 0xabcd, 1, 2, 3, 4, 5]), 32)
-                .normalized()
-                .network(),
-            v6([0x2001, 0xdb8, 0, 0, 0, 0, 0, 0])
-        );
-        assert_eq!(
-            cidr(v4(10, 1, 2, 3), 0).normalized().network(),
-            v4(0, 0, 0, 0)
-        );
+    fn cidr_rejects_invalid_prefixes_and_mixed_families() {
         assert_eq!(
             Cidr::new(v4(10, 1, 2, 3), 33),
             Err(InvalidCidrPrefix {

--- a/crates/xray-routing/src/lib.rs
+++ b/crates/xray-routing/src/lib.rs
@@ -1,8 +1,10 @@
 use std::net::IpAddr;
 use thiserror::Error;
 
+pub mod ip_filter;
 pub mod ip_range_set;
 
+pub use ip_filter::{DnsIpFilter, DnsIpFilterBuilder};
 pub use ip_range_set::{
     canonicalize_ip, Cidr, InvalidCidrPrefix, IpMatcherSet, IpMatcherSetBuilder, IpRangeSet,
     IpRangeSetBuilder, PRIVATE_NETWORKS,

--- a/crates/xray-transport/src/dns.rs
+++ b/crates/xray-transport/src/dns.rs
@@ -6,12 +6,11 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UdpSocket;
 use tokio::sync::Notify;
 use tokio::time;
-use xray_routing::{Cidr, IpMatcherSet, IpMatcherSetBuilder};
+use xray_routing::DnsIpFilter;
 
 use crate::{
     canonicalize_socket_addr, connect_tcp_happy_eyeballs, HappyEyeballsConfig, SocketHandle,
@@ -603,201 +602,6 @@ pub enum NameServer {
     Domain { domain: String, port: u16 },
 }
 
-/// A normalized IP network used by managed-DNS response filters.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DnsIpCidr(Cidr);
-
-impl DnsIpCidr {
-    pub fn new(network: IpAddr, prefix_len: u8) -> Result<Self, DnsIpCidrError> {
-        Cidr::new(network, prefix_len)
-            .map(|cidr| Self(cidr.normalized()))
-            .map_err(|error| DnsIpCidrError::PrefixTooLong {
-                address: error.address,
-                prefix_len: error.prefix_len,
-                max_prefix: error.max_prefix,
-            })
-    }
-
-    pub fn host(address: IpAddr) -> Self {
-        Self(Cidr::host(address))
-    }
-
-    pub fn network(self) -> IpAddr {
-        self.0.network()
-    }
-
-    pub fn prefix_len(self) -> u8 {
-        self.0.prefix_len()
-    }
-
-    pub fn contains(self, address: IpAddr) -> bool {
-        self.0.contains(address)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
-pub enum DnsIpCidrError {
-    #[error("DNS IP CIDR prefix length {prefix_len} exceeds {max_prefix} for address {address}")]
-    PrefixTooLong {
-        address: IpAddr,
-        prefix_len: u8,
-        max_prefix: u8,
-    },
-}
-
-/// One portable rule in an Xray-compatible managed-DNS IP filter.
-///
-/// Positive rules within one category are ORed. Inverse rules within the same
-/// category mean "outside every inverse network", matching Xray's optimized
-/// IP-set behavior rather than ORing individual negations.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DnsIpMatcher {
-    Cidr(DnsIpCidr),
-    Private,
-    Not(Box<DnsIpMatcher>),
-}
-
-impl DnsIpMatcher {
-    pub fn cidr(network: IpAddr, prefix_len: u8) -> Result<Self, DnsIpCidrError> {
-        DnsIpCidr::new(network, prefix_len).map(Self::Cidr)
-    }
-
-    pub fn host(address: IpAddr) -> Self {
-        Self::Cidr(DnsIpCidr::host(address))
-    }
-
-    pub fn inverted(self) -> Self {
-        Self::Not(Box::new(self))
-    }
-}
-
-/// Source form of one `expectedIPs` or `unexpectedIPs` filter.
-///
-/// `custom_matchers` and `geoip_matchers` are independent Xray matcher
-/// categories and are ORed together. `soft` corresponds to the `*` marker:
-/// the preferred subset is used only when it is non-empty.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DnsIpFilter {
-    pub custom_matchers: Vec<DnsIpMatcher>,
-    pub geoip_matchers: Vec<DnsIpMatcher>,
-    pub soft: bool,
-}
-
-impl DnsIpFilter {
-    pub fn new(
-        custom_matchers: Vec<DnsIpMatcher>,
-        geoip_matchers: Vec<DnsIpMatcher>,
-        soft: bool,
-    ) -> Self {
-        Self {
-            custom_matchers,
-            geoip_matchers,
-            soft,
-        }
-    }
-
-    pub fn hard(custom_matchers: Vec<DnsIpMatcher>, geoip_matchers: Vec<DnsIpMatcher>) -> Self {
-        Self::new(custom_matchers, geoip_matchers, false)
-    }
-
-    pub fn soft(custom_matchers: Vec<DnsIpMatcher>, geoip_matchers: Vec<DnsIpMatcher>) -> Self {
-        Self::new(custom_matchers, geoip_matchers, true)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.custom_matchers.is_empty() && self.geoip_matchers.is_empty()
-    }
-}
-
-/// Query-ready managed-DNS IP filter compiled into merged address ranges.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CompiledDnsIpFilter {
-    custom: IpMatcherSet,
-    geoip: IpMatcherSet,
-    soft: bool,
-    matcher_count: usize,
-}
-
-impl CompiledDnsIpFilter {
-    pub fn new(filter: DnsIpFilter) -> Self {
-        let matcher_count = filter.custom_matchers.len() + filter.geoip_matchers.len();
-        Self {
-            custom: compile_dns_ip_matchers(filter.custom_matchers),
-            geoip: compile_dns_ip_matchers(filter.geoip_matchers),
-            soft: filter.soft,
-            matcher_count,
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.custom.is_empty() && self.geoip.is_empty()
-    }
-
-    pub fn is_soft(&self) -> bool {
-        self.soft
-    }
-
-    /// Returns the number of source matcher entries supplied to the filter.
-    ///
-    /// `Private` counts as one source entry even though compilation expands it
-    /// into the nine Xray private-address networks. A wrapping `Not` also does
-    /// not change the source count.
-    pub fn matcher_count(&self) -> usize {
-        self.matcher_count
-    }
-
-    /// Returns the deterministic number of merged ranges retained by the
-    /// query-time index across custom/GeoIP, positive/inverse, and IP-family
-    /// partitions.
-    pub fn compiled_range_count(&self) -> usize {
-        self.custom.range_count() + self.geoip.range_count()
-    }
-
-    pub fn matches(&self, address: IpAddr) -> bool {
-        self.custom.matches(address) || self.geoip.matches(address)
-    }
-
-    /// Applies this filter as `expectedIPs` and returns false when a hard
-    /// filter rejects every candidate.
-    pub fn apply_expected(&self, addresses: &mut Vec<IpAddr>) -> bool {
-        self.retain_preferred(addresses, true)
-    }
-
-    /// Applies this filter as `unexpectedIPs` and returns false when a hard
-    /// filter rejects every candidate.
-    pub fn apply_unexpected(&self, addresses: &mut Vec<IpAddr>) -> bool {
-        self.retain_preferred(addresses, false)
-    }
-
-    fn retain_preferred(&self, addresses: &mut Vec<IpAddr>, keep_matches: bool) -> bool {
-        if self.is_empty() {
-            return true;
-        }
-        let preferred = |address: &IpAddr| self.matches(*address) == keep_matches;
-        if self.soft && !addresses.iter().any(&preferred) {
-            return true;
-        }
-        addresses.retain(preferred);
-        !addresses.is_empty()
-    }
-}
-
-fn compile_dns_ip_matchers(matchers: Vec<DnsIpMatcher>) -> IpMatcherSet {
-    let mut builder = IpMatcherSet::builder();
-    for matcher in matchers {
-        insert_dns_ip_matcher(&mut builder, matcher, false);
-    }
-    builder.build()
-}
-
-fn insert_dns_ip_matcher(builder: &mut IpMatcherSetBuilder, matcher: DnsIpMatcher, inverted: bool) {
-    match matcher {
-        DnsIpMatcher::Cidr(cidr) => builder.insert_cidr(cidr.0, inverted),
-        DnsIpMatcher::Private => builder.insert_private_networks(inverted),
-        DnsIpMatcher::Not(matcher) => insert_dns_ip_matcher(builder, *matcher, !inverted),
-    }
-}
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum DnsQueryStrategy {
     #[default]
@@ -1073,8 +877,8 @@ impl CompiledNameServerPolicies {
                     tag,
                     transport,
                     domains,
-                    expected_ips: compile_dns_ip_filter(expected_ips),
-                    unexpected_ips: compile_dns_ip_filter(unexpected_ips),
+                    expected_ips,
+                    unexpected_ips,
                     skip_fallback,
                     query_strategy,
                     final_query,
@@ -1186,8 +990,8 @@ struct CompiledNameServerPolicy {
     tag: Option<String>,
     transport: NameServerTransport,
     domains: CompiledDomainMatcherSet,
-    expected_ips: Option<CompiledDnsIpFilter>,
-    unexpected_ips: Option<CompiledDnsIpFilter>,
+    expected_ips: DnsIpFilter,
+    unexpected_ips: DnsIpFilter,
     skip_fallback: bool,
     query_strategy: DnsQueryStrategy,
     final_query: bool,
@@ -1199,45 +1003,20 @@ impl CompiledNameServerPolicy {
         // Xray applies both mandatory filters before either preference filter.
         // The mixed-mode ordering is observable when one filter removes the
         // only subset preferred by the other.
-        if self
-            .expected_ips
-            .as_ref()
-            .filter(|filter| !filter.is_soft())
-            .is_some_and(|filter| !filter.apply_expected(addresses))
-        {
+        if !self.expected_ips.is_soft() && !self.expected_ips.apply_expected(addresses) {
             return false;
         }
-        if self
-            .unexpected_ips
-            .as_ref()
-            .filter(|filter| !filter.is_soft())
-            .is_some_and(|filter| !filter.apply_unexpected(addresses))
-        {
+        if !self.unexpected_ips.is_soft() && !self.unexpected_ips.apply_unexpected(addresses) {
             return false;
         }
-        if self
-            .expected_ips
-            .as_ref()
-            .filter(|filter| filter.is_soft())
-            .is_some_and(|filter| !filter.apply_expected(addresses))
-        {
+        if self.expected_ips.is_soft() && !self.expected_ips.apply_expected(addresses) {
             return false;
         }
-        if self
-            .unexpected_ips
-            .as_ref()
-            .filter(|filter| filter.is_soft())
-            .is_some_and(|filter| !filter.apply_unexpected(addresses))
-        {
+        if self.unexpected_ips.is_soft() && !self.unexpected_ips.apply_unexpected(addresses) {
             return false;
         }
         true
     }
-}
-
-fn compile_dns_ip_filter(filter: DnsIpFilter) -> Option<CompiledDnsIpFilter> {
-    let compiled = CompiledDnsIpFilter::new(filter);
-    (!compiled.is_empty()).then_some(compiled)
 }
 
 #[derive(Debug, Default)]
@@ -2708,12 +2487,12 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, UdpSocket};
     use tokio::sync::{oneshot, Barrier, Notify};
+    use xray_routing::{Cidr, DnsIpFilter};
 
     use super::{
         build_dns_query_with_id, parse_dns_response, query_udp_dns_server,
-        select_name_server_indices, CachingDnsResolver, CompiledDnsIpFilter,
-        CompiledNameServerPolicies, ConfiguredDnsAddresses, ConfiguredDnsAnswer,
-        ConfiguredDnsResolver, DnsIpCidr, DnsIpCidrError, DnsIpFilter, DnsIpMatcher, DnsLookup,
+        select_name_server_indices, CachingDnsResolver, CompiledNameServerPolicies,
+        ConfiguredDnsAddresses, ConfiguredDnsAnswer, ConfiguredDnsResolver, DnsLookup,
         DnsQueryDispatch, DnsQueryMetadata, DnsQueryStrategy, DnsQueryTransport,
         DnsQueryTransportKind, DnsRecordType, DnsResolver, NameServer, NameServerPolicy,
         NameServerTransport, StaticHostRule, StaticHostTarget, TransportDomainMatcher,
@@ -2729,199 +2508,34 @@ mod tests {
         assert_eq!(&query[..2], &0xA17E_u16.to_be_bytes());
     }
 
-    fn dns_ip_cidr(network: &str, prefix_len: u8) -> DnsIpMatcher {
-        DnsIpMatcher::cidr(network.parse().expect("valid test IP address"), prefix_len)
+    fn dns_ip_cidr(network: &str, prefix_len: u8) -> Cidr {
+        Cidr::new(network.parse().expect("valid test IP address"), prefix_len)
             .expect("valid test prefix")
     }
 
-    fn hard_dns_ip_filter(matchers: Vec<DnsIpMatcher>) -> CompiledDnsIpFilter {
-        CompiledDnsIpFilter::new(DnsIpFilter::hard(matchers, Vec::new()))
+    fn dns_ip_filter(cidrs: &[Cidr], soft: bool) -> DnsIpFilter {
+        let mut builder = DnsIpFilter::builder();
+        for cidr in cidrs {
+            builder.custom().insert_cidr(*cidr, false);
+        }
+        builder.set_soft(soft);
+        builder.build()
     }
 
-    fn soft_dns_ip_filter(matchers: Vec<DnsIpMatcher>) -> CompiledDnsIpFilter {
-        CompiledDnsIpFilter::new(DnsIpFilter::soft(matchers, Vec::new()))
+    fn hard_dns_ip_filter(cidrs: &[Cidr]) -> DnsIpFilter {
+        dns_ip_filter(cidrs, false)
     }
 
-    #[test]
-    fn dns_ip_cidr_normalizes_network_and_validates_prefix() {
-        let cidr = DnsIpCidr::new(Ipv4Addr::new(192, 0, 2, 129).into(), 24).unwrap();
-
-        assert_eq!(cidr.network(), IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)));
-        assert_eq!(cidr.prefix_len(), 24);
-        assert!(cidr.contains(Ipv4Addr::new(192, 0, 2, 255).into()));
-        assert!(!cidr.contains(Ipv4Addr::new(192, 0, 3, 1).into()));
-        assert_eq!(
-            DnsIpCidr::new(Ipv4Addr::LOCALHOST.into(), 33),
-            Err(DnsIpCidrError::PrefixTooLong {
-                address: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                prefix_len: 33,
-                max_prefix: 32,
-            })
-        );
-
-        let mapped = Ipv4Addr::new(192, 0, 2, 129).to_ipv6_mapped();
-        let mapped_cidr = DnsIpCidr::new(IpAddr::V6(mapped), 24).unwrap();
-        assert_eq!(
-            (mapped_cidr.network(), mapped_cidr.prefix_len()),
-            (IpAddr::V4(Ipv4Addr::new(192, 0, 2, 0)), 24)
-        );
-        assert_eq!(
-            DnsIpCidr::new(IpAddr::V6(mapped), 120),
-            Err(DnsIpCidrError::PrefixTooLong {
-                address: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 129)),
-                prefix_len: 120,
-                max_prefix: 32,
-            })
-        );
-        assert_eq!(
-            DnsIpCidr::host(IpAddr::V6(mapped)),
-            DnsIpCidr::host(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 129)))
-        );
-    }
-
-    #[test]
-    fn compiled_dns_ip_filter_matches_private_and_reports_deterministic_stats() {
-        let filter = hard_dns_ip_filter(vec![DnsIpMatcher::Private]);
-
-        assert_eq!(filter.matcher_count(), 1);
-        assert_eq!(filter.compiled_range_count(), 9);
-        assert!(filter.matches(Ipv4Addr::new(10, 1, 2, 3).into()));
-        assert!(filter.matches(Ipv4Addr::new(100, 64, 1, 2).into()));
-        assert!(filter.matches(Ipv6Addr::LOCALHOST.into()));
-        assert!(filter.matches(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1).into()));
-        assert!(!filter.matches(Ipv4Addr::new(8, 8, 8, 8).into()));
-        assert!(!filter.matches(Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888).into()));
-    }
-
-    #[test]
-    fn compiled_dns_ip_filter_merges_ranges_without_losing_source_count() {
-        let filter = hard_dns_ip_filter(vec![
-            dns_ip_cidr("192.0.2.0", 25),
-            dns_ip_cidr("192.0.2.128", 25),
-        ]);
-
-        assert_eq!(filter.matcher_count(), 2);
-        assert_eq!(filter.compiled_range_count(), 1);
-        assert!(filter.matches(Ipv4Addr::new(192, 0, 2, 255).into()));
-    }
-
-    #[test]
-    fn inverse_dns_ip_matchers_complement_the_union_for_their_address_family() {
-        let filter = hard_dns_ip_filter(vec![
-            dns_ip_cidr("10.0.0.0", 8).inverted(),
-            dns_ip_cidr("192.168.0.0", 16).inverted(),
-        ]);
-
-        assert!(filter.matches(Ipv4Addr::new(203, 0, 113, 7).into()));
-        assert!(!filter.matches(Ipv4Addr::new(10, 2, 3, 4).into()));
-        assert!(!filter.matches(Ipv4Addr::new(192, 168, 5, 6).into()));
-        assert!(!filter.matches(Ipv6Addr::LOCALHOST.into()));
-    }
-
-    #[test]
-    fn custom_and_geoip_dns_matcher_categories_are_ored() {
-        let filter = CompiledDnsIpFilter::new(DnsIpFilter::hard(
-            vec![dns_ip_cidr("192.0.2.0", 24)],
-            vec![dns_ip_cidr("2001:db8::", 32)],
-        ));
-
-        assert!(filter.matches(Ipv4Addr::new(192, 0, 2, 10).into()));
-        assert!(filter.matches(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 10).into()));
-        assert!(!filter.matches(Ipv4Addr::new(198, 51, 100, 10).into()));
-    }
-
-    #[test]
-    fn inverse_custom_and_geoip_dns_matcher_categories_remain_independent() {
-        let filter = CompiledDnsIpFilter::new(DnsIpFilter::hard(
-            vec![dns_ip_cidr("10.0.0.0", 8).inverted()],
-            vec![dns_ip_cidr("192.168.0.0", 16).inverted()],
-        ));
-
-        // Each inverse category is its own Xray submatcher; the category not
-        // containing the address still makes the multi-matcher succeed.
-        assert!(filter.matches(Ipv4Addr::new(10, 1, 2, 3).into()));
-        assert!(filter.matches(Ipv4Addr::new(192, 168, 1, 2).into()));
-    }
-
-    #[test]
-    fn dns_ip_filter_unmaps_ipv4_mapped_match_inputs_like_xray() {
-        let filter = hard_dns_ip_filter(vec![dns_ip_cidr("192.0.2.0", 24)]);
-
-        assert!(filter.matches(IpAddr::V6(Ipv4Addr::new(192, 0, 2, 10).to_ipv6_mapped())));
-    }
-
-    #[test]
-    fn expected_dns_ip_filters_keep_matching_candidates_with_hard_and_soft_semantics() {
-        let matching_v4 = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
-        let matching_v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 10));
-        let rejected = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10));
-        let matchers = vec![dns_ip_cidr("192.0.2.0", 24), dns_ip_cidr("2001:db8::", 32)];
-        let hard = hard_dns_ip_filter(matchers.clone());
-        let soft = soft_dns_ip_filter(matchers);
-
-        let mut hard_candidates = vec![matching_v6, rejected, matching_v4, matching_v6];
-        assert!(hard.apply_expected(&mut hard_candidates));
-        assert_eq!(hard_candidates, [matching_v6, matching_v4, matching_v6]);
-
-        let mut hard_rejected = vec![rejected];
-        assert!(!hard.apply_expected(&mut hard_rejected));
-        assert!(hard_rejected.is_empty());
-
-        let mut soft_preferred = vec![rejected, matching_v4];
-        assert!(soft.apply_expected(&mut soft_preferred));
-        assert_eq!(soft_preferred, [matching_v4]);
-
-        let mut soft_fallback = vec![rejected, rejected];
-        assert!(soft.apply_expected(&mut soft_fallback));
-        assert_eq!(soft_fallback, [rejected, rejected]);
-    }
-
-    #[test]
-    fn unexpected_dns_ip_filters_keep_nonmatching_candidates_with_hard_and_soft_semantics() {
-        let unexpected = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10));
-        let preferred_v4 = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 10));
-        let preferred_v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 10));
-        let matcher = vec![dns_ip_cidr("192.0.2.0", 24)];
-        let hard = hard_dns_ip_filter(matcher.clone());
-        let soft = soft_dns_ip_filter(matcher);
-
-        let mut hard_candidates = vec![unexpected, preferred_v4, preferred_v6, preferred_v4];
-        assert!(hard.apply_unexpected(&mut hard_candidates));
-        assert_eq!(hard_candidates, [preferred_v4, preferred_v6, preferred_v4]);
-
-        let mut hard_rejected = vec![unexpected, unexpected];
-        assert!(!hard.apply_unexpected(&mut hard_rejected));
-        assert!(hard_rejected.is_empty());
-
-        let mut soft_preferred = vec![unexpected, preferred_v4];
-        assert!(soft.apply_unexpected(&mut soft_preferred));
-        assert_eq!(soft_preferred, [preferred_v4]);
-
-        let mut soft_fallback = vec![unexpected, unexpected];
-        assert!(soft.apply_unexpected(&mut soft_fallback));
-        assert_eq!(soft_fallback, [unexpected, unexpected]);
-    }
-
-    #[test]
-    fn empty_dns_ip_filter_is_a_noop_even_when_hard() {
-        let filter = CompiledDnsIpFilter::new(DnsIpFilter::default());
-        let original = vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))];
-        let mut expected = original.clone();
-        let mut unexpected = original.clone();
-
-        assert!(filter.is_empty());
-        assert!(filter.apply_expected(&mut expected));
-        assert!(filter.apply_unexpected(&mut unexpected));
-        assert_eq!(expected, original);
-        assert_eq!(unexpected, original);
+    fn soft_dns_ip_filter(cidrs: &[Cidr]) -> DnsIpFilter {
+        dns_ip_filter(cidrs, true)
     }
 
     #[test]
     fn compiled_name_server_policy_applies_expected_before_soft_unexpected() {
         let server = NameServer::Socket(SocketAddr::from(([192, 0, 2, 53], 53)));
         let mut policy = NameServerPolicy::new(server);
-        policy.expected_ips = DnsIpFilter::hard(vec![dns_ip_cidr("192.0.2.0", 24)], Vec::new());
-        policy.unexpected_ips = DnsIpFilter::soft(vec![dns_ip_cidr("192.0.2.0", 24)], Vec::new());
+        policy.expected_ips = hard_dns_ip_filter(&[dns_ip_cidr("192.0.2.0", 24)]);
+        policy.unexpected_ips = soft_dns_ip_filter(&[dns_ip_cidr("192.0.2.0", 24)]);
         let policies = CompiledNameServerPolicies::new(vec![policy]);
         let mut addresses = vec![
             IpAddr::V4(Ipv4Addr::new(198, 51, 100, 1)),
@@ -2936,8 +2550,8 @@ mod tests {
     fn compiled_name_server_policy_applies_hard_unexpected_before_soft_expected() {
         let server = NameServer::Socket(SocketAddr::from(([192, 0, 2, 53], 53)));
         let mut policy = NameServerPolicy::new(server);
-        policy.expected_ips = DnsIpFilter::soft(vec![dns_ip_cidr("192.0.2.0", 24)], Vec::new());
-        policy.unexpected_ips = DnsIpFilter::hard(vec![dns_ip_cidr("192.0.2.0", 24)], Vec::new());
+        policy.expected_ips = soft_dns_ip_filter(&[dns_ip_cidr("192.0.2.0", 24)]);
+        policy.unexpected_ips = hard_dns_ip_filter(&[dns_ip_cidr("192.0.2.0", 24)]);
         let policies = CompiledNameServerPolicies::new(vec![policy]);
         let mut addresses = vec![
             IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)),
@@ -4056,13 +3670,10 @@ mod tests {
     async fn configured_dns_filters_merged_families_without_reordering_or_recomputing_ttl() {
         let server = NameServer::Socket(SocketAddr::from(([192, 0, 2, 53], 53)));
         let mut policy = NameServerPolicy::new(server);
-        policy.expected_ips = DnsIpFilter::hard(
-            vec![
-                DnsIpMatcher::host(Ipv4Addr::new(192, 0, 2, 80).into()),
-                DnsIpMatcher::host(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 80).into()),
-            ],
-            Vec::new(),
-        );
+        policy.expected_ips = hard_dns_ip_filter(&[
+            Cidr::host(Ipv4Addr::new(192, 0, 2, 80).into()),
+            Cidr::host(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 80).into()),
+        ]);
         let resolver =
             ConfiguredDnsResolver::new(Vec::new(), Vec::new(), Arc::new(RejectingResolver))
                 .with_name_server_policies(vec![policy])
@@ -5243,8 +4854,7 @@ mod tests {
         let filtered = NameServer::Socket(SocketAddr::from(([192, 0, 2, 1], 53)));
         let fallback = NameServer::Socket(SocketAddr::from(([192, 0, 2, 2], 53)));
         let mut filtered_policy = NameServerPolicy::new(filtered.clone());
-        filtered_policy.expected_ips =
-            DnsIpFilter::hard(vec![dns_ip_cidr("203.0.113.0", 24)], Vec::new());
+        filtered_policy.expected_ips = hard_dns_ip_filter(&[dns_ip_cidr("203.0.113.0", 24)]);
         let transport = Arc::new(FilteredCnameFailoverQueryTransport {
             filtered_server: filtered.clone(),
             calls: Mutex::new(Vec::new()),

--- a/crates/xray-transport/src/lib.rs
+++ b/crates/xray-transport/src/lib.rs
@@ -32,8 +32,7 @@ mod utls_tls;
 pub use dialer::TransportDialer;
 pub use dns::{
     dns_response_matches_query, select_name_server_indices, CachingDnsResolver,
-    CompiledDnsIpFilter, CompiledDomainMatcherSet, CompiledNameServerPolicies,
-    ConfiguredDnsResolver, DnsIpCidr, DnsIpCidrError, DnsIpFilter, DnsIpMatcher, DnsLookup,
+    CompiledDomainMatcherSet, CompiledNameServerPolicies, ConfiguredDnsResolver, DnsLookup,
     DnsQueryDispatch, DnsQueryMetadata, DnsQueryStrategy, DnsQueryTransport, DnsQueryTransportKind,
     DnsResolver, NameServer, NameServerPolicy, NameServerTransport, StaticHostRule,
     StaticHostTarget, SystemDnsResolver, TransportDomainMatcher, TransportRegexMatcher,


### PR DESCRIPTION
## Summary

Follow-up to #16. After the shared range index landed, `xray_config::IpMatcher` was pure data with a single consumer — `DnsIpFilter { custom_matchers, geoip_matchers }` — which `xray-core-rs` converted 1:1 into `xray_transport::DnsIpMatcher` so that transport could compile it. Routing rules already compiled in the parser; DNS filters now do the same, and the mirrored enums disappear.

- **xray-routing** — new `ip_filter` module: `DnsIpFilter { custom: IpMatcherSet, geoip: IpMatcherSet, soft, matcher_count }` + `DnsIpFilterBuilder { custom(), geoip(), set_soft(), build() }` — the former transport `CompiledDnsIpFilter` (same `matches`, `is_empty`, `is_soft`, `matcher_count`, `compiled_range_count`, `apply_expected`, `apply_unexpected`). One name everywhere; `ip_range_set.rs` keeps only the generic range/matcher types. `IpMatcherSetBuilder` now tracks `matcher_count` (one per CIDR/`Private`; inversion adds nothing) and gains `insert_ip`. `Cidr::normalized` removed — no callers left. Pure-filter tests moved here from transport (5 tests: category OR, inverse-per-category, soft/hard apply, counts, empty).
- **xray-config** — `DnsIpFilter` is now `pub use xray_routing::DnsIpFilter` (same name, no alias). The parser writes into the builders directly: `parse_dns_ip_filter` picks `geoip()`/`custom()` by `dns_ip_rule_uses_geodata`, `*` → `set_soft(true)`; `parse_ip_matchers` returns `IpMatcherSet`; `parse_ip_matcher*`/`parse_geoip_matchers`/`parse_external_geoip_matchers` and the geodata loaders take `&mut IpMatcherSetBuilder` and return the number of matchers inserted, so `MAX_CONFIG_IP_MATCHERS` accounting and diagnostics (paths, messages) are unchanged. Removed: `IpMatcher`, `compile_ip_matchers`, `wrap_ip_matcher_inverse`, `geodata::wrap_inverse`.
  - `DnsServerConfig::Policy` now holds `Box<DnsNameServerConfig>`: two compiled filters (144 B each) made the variant ~12× larger than `Domain`, and `clippy::large_enum_variant` fails under the CI lint set. Seven construction sites gained `Box::new`; match sites are unchanged via auto-deref.
- **xray-transport** — removed `DnsIpCidr`, `DnsIpCidrError`, `DnsIpMatcher`, source `DnsIpFilter`, `CompiledDnsIpFilter`, `compile_dns_ip_matchers`, `insert_dns_ip_matcher` (~200 lines). `NameServerPolicy` and `CompiledNameServerPolicy` carry `DnsIpFilter` directly — an empty filter is already a no-op in `apply_*`, so the `Option` wrapper and `compile_dns_ip_filter` are gone and `apply_ip_filters` is four plain `if`s.
- **xray-core-rs** — `into_transport_dns_ip_filter` / `into_transport_dns_ip_matcher` removed; filters pass straight through.
- **xray-bench** — dns-policy-probe builds its host list with `DnsIpFilter::builder().custom().insert_ip(..)`; the probe addresses are generated before the `compile_us` timer starts, so the metric covers filter construction only, as before. Still reports `matcher_count` / `compiled_range_count`.

Result: one compiled IP-matcher type and one compiled IP-filter type in the workspace, both in `xray-routing`; `grep -rn "IpMatcher\b\|DnsIpMatcher\|DnsIpCidr\|compile_ip_matchers\|into_transport_dns_ip\|CompiledDnsIpFilter" crates` is empty.

No behaviour change intended. Budget/diagnostic coverage: `parser.rs` `dns_ip_filters_consume_the_global_ip_matcher_budget`, `default_matcher_budget_enforces_domain_ip_and_combined_limits`, `ignored_expect_ips_alias_does_not_consume_matcher_budget`, `repeated_cached_geosite_is_rejected_by_global_matcher_budget`; `geodata.rs` `IpMatcherBudgetExceeded` test; `parser_tests.rs` geoip/ext-ip/`*`/alias tests (assertions now via `filter.matches(ip)`, `is_soft()`, `is_empty()`, `matcher_count()`).

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --exclude xray-rust-fuzz --all-targets --all-features -- -D warnings -W clippy::perf -W clippy::suspicious` — clean (fuzz crate excluded only because `libfuzzer-sys` can't build its C++ on the dev machine; CI runs the full set)
- `cargo test -p xray-routing -p xray-config -p xray-transport -p xray-core-rs` — 1500 passed, 0 failed, 28 ignored (network/interop); `cargo test -p xray-bench --lib` — 194 passed

## Benchmark

**Hardware/OS:** Apple M2 Pro (12 cores), 32 GB RAM, macOS 26.6.2; rustc/cargo 1.96.0; `cargo build --release -p xray-bench`; single process, no other load. BEFORE is `main` (after #16); 3 warm runs.

| Command | Before | After |
|---|---|---|
| `route-probe --iterations 100000 --rules 64 --outbounds 8` | 519 / 484 / 483 ns | 484 / 467 / 489 ns |
| `route-probe --iterations 100000 --rules 16 --outbounds 8 --cidrs-per-rule 5000` | 493 / 491 / 497 ns | 486 / 494 / 488 ns |
| `dns-policy-probe` (defaults) ip-filter | compile 93/89/81 µs · matchers 4096 · ranges 4096 · hit 10 ns · miss 12 ns | compile 82/83/79/86/80 µs · matchers 4096 · ranges 4096 · hit 10 ns · miss 12 ns |

Parity throughout. In both columns `compile_us` covers filter construction only (probe address generation happens before the timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


