### PR TITLE
refactor(ffi): validate TUN poll out-buffers through OutStrBuf and shared handle helpers

### DIFF
--- a/crates/xray-ffi/src/lib.rs
+++ b/crates/xray-ffi/src/lib.rs
@@ -1728,6 +1728,7 @@ pub unsafe extern "C" fn xray_tun_poll_packet(
     unsafe {
         ffi_status(error, || {
             xray_tun_poll_packet_inner(handle, buffer, buffer_len, written, error)
+                .unwrap_or_else(|status| status)
         })
     }
 }
@@ -1738,7 +1739,7 @@ unsafe fn xray_tun_poll_packet_inner(
     buffer_len: usize,
     written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
@@ -1749,38 +1750,12 @@ unsafe fn xray_tun_poll_packet_inner(
         }
     }
 
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe {
+        ensure_non_null(buffer, error, "packet buffer is null")?;
+        ensure_non_null(written, error, "written pointer is null")?;
     }
-    if buffer.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "packet buffer is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if written.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "written pointer is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
-    };
+    let core = unsafe { loaded_core(handle, error)? };
 
     let pending_packet = match handle.pending_outbound_packets.lock() {
         Ok(mut pending_packets) => pending_packets.pop_front(),
@@ -1798,7 +1773,7 @@ unsafe fn xray_tun_poll_packet_inner(
                 ptr::copy_nonoverlapping(packet.as_ptr(), buffer, packet.len());
                 *written = packet.len();
             }
-            XrayStatus::Ok
+            Ok(XrayStatus::Ok)
         }
         Ok(Some(packet)) => {
             unsafe {
@@ -1816,14 +1791,14 @@ unsafe fn xray_tun_poll_packet_inner(
                 Ok(mut pending_packets) => pending_packets.push_front(packet),
                 Err(poisoned) => poisoned.into_inner().push_front(packet),
             }
-            XrayStatus::BufferTooSmall
+            Err(XrayStatus::BufferTooSmall)
         }
-        Ok(None) => XrayStatus::NoPacket,
+        Ok(None) => Ok(XrayStatus::NoPacket),
         Err(err) => {
             unsafe {
                 set_error(error, XrayStatus::TunError, err.to_string());
             }
-            XrayStatus::TunError
+            Err(XrayStatus::TunError)
         }
     }
 }
@@ -1876,6 +1851,7 @@ pub unsafe extern "C" fn xray_tun_poll_packets(
                 wait_ms,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -1890,7 +1866,7 @@ unsafe fn xray_tun_poll_packets_inner(
     packet_count: *mut usize,
     wait_ms: u32,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
@@ -1901,37 +1877,11 @@ unsafe fn xray_tun_poll_packets_inner(
         }
     }
 
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if buffer.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "packet buffer is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if packet_lengths.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "packet lengths pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if packet_count.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "packet count pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe {
+        ensure_non_null(buffer, error, "packet buffer is null")?;
+        ensure_non_null(packet_lengths, error, "packet lengths pointer is null")?;
+        ensure_non_null(packet_count, error, "packet count pointer is null")?;
     }
     if max_packets == 0 {
         unsafe {
@@ -1941,20 +1891,9 @@ unsafe fn xray_tun_poll_packets_inner(
                 "max_packets must be nonzero",
             );
         }
-        return XrayStatus::NullArgument;
+        return Err(XrayStatus::NullArgument);
     }
-
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
-    };
+    let core = unsafe { loaded_core(handle, error)? };
 
     let tun = core.tun();
     // Every outbound packet is bounded by the tun mtu, so reserving one mtu of
@@ -1971,7 +1910,7 @@ unsafe fn xray_tun_poll_packets_inner(
                 ),
             );
         }
-        return XrayStatus::BufferTooSmall;
+        return Err(XrayStatus::BufferTooSmall);
     }
 
     let pending_packet = match handle.pending_outbound_packets.lock() {
@@ -1984,7 +1923,7 @@ unsafe fn xray_tun_poll_packets_inner(
             *packet_lengths = packet.len();
             *packet_count = 1;
         }
-        return XrayStatus::Ok;
+        return Ok(XrayStatus::Ok);
     }
 
     let wait = Duration::from_millis(u64::from(wait_ms));
@@ -1993,14 +1932,14 @@ unsafe fn xray_tun_poll_packets_inner(
     });
 
     match batch {
-        Err(_) => XrayStatus::NoPacket,
+        Err(_) => Ok(XrayStatus::NoPacket),
         Ok(Err(err)) => {
             unsafe {
                 set_error(error, XrayStatus::TunError, err.to_string());
             }
-            XrayStatus::TunError
+            Err(XrayStatus::TunError)
         }
-        Ok(Ok(packets)) if packets.is_empty() => XrayStatus::NoPacket,
+        Ok(Ok(packets)) if packets.is_empty() => Ok(XrayStatus::NoPacket),
         Ok(Ok(packets)) => {
             let mut offset = 0usize;
             let mut written = 0usize;
@@ -2018,7 +1957,7 @@ unsafe fn xray_tun_poll_packets_inner(
             unsafe {
                 *packet_count = written;
             }
-            XrayStatus::Ok
+            Ok(XrayStatus::Ok)
         }
     }
 }
@@ -2056,6 +1995,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_slow_flow_event(
                 target_written,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2067,85 +2007,26 @@ unsafe fn xray_tun_poll_tcp_slow_flow_event_inner(
     target_buffer_len: usize,
     target_written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
-
-    if !target_written.is_null() {
-        unsafe {
-            *target_written = 0;
-        }
-    }
-    if !target_buffer.is_null() && target_buffer_len > 0 {
-        unsafe {
-            *target_buffer = 0;
-        }
-    }
-
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if event.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "slow-flow event pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "slow-flow target buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "slow-flow target written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "slow-flow target buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
+    let target = unsafe {
+        OutStrArgs::new(
+            target_buffer,
+            target_buffer_len,
+            target_written,
+            "slow-flow target",
+        )
     };
 
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe { ensure_non_null(event, error, "slow-flow event pointer is null")? };
+    let [target] = unsafe { OutStrArgs::validate([target], error)? };
+    let core = unsafe { loaded_core(handle, error)? };
+
     let Some(slow_flow) = core.tun().poll_tcp_slow_flow_event() else {
-        return XrayStatus::NoPacket;
+        return Ok(XrayStatus::NoPacket);
     };
 
     unsafe {
@@ -2154,14 +2035,9 @@ unsafe fn xray_tun_poll_tcp_slow_flow_event_inner(
             open_duration_ms: slow_flow.open_duration_ms,
             first_byte_duration_ms: slow_flow.first_byte_duration_ms,
         };
-        write_c_string_truncated(
-            &slow_flow.target,
-            target_buffer,
-            target_buffer_len,
-            target_written,
-        );
+        target.write(&slow_flow.target);
     }
-    XrayStatus::Ok
+    Ok(XrayStatus::Ok)
 }
 
 /// Polls one debug-only TCP flow-summary event from the TUN endpoint.
@@ -2202,6 +2078,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_flow_summary_event(
                 outbound_tag_written,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2217,125 +2094,34 @@ unsafe fn xray_tun_poll_tcp_flow_summary_event_inner(
     outbound_tag_buffer_len: usize,
     outbound_tag_written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
-
-    if !target_written.is_null() {
-        unsafe {
-            *target_written = 0;
-        }
-    }
-    if !target_buffer.is_null() && target_buffer_len > 0 {
-        unsafe {
-            *target_buffer = 0;
-        }
-    }
-    if !outbound_tag_written.is_null() {
-        unsafe {
-            *outbound_tag_written = 0;
-        }
-    }
-    if !outbound_tag_buffer.is_null() && outbound_tag_buffer_len > 0 {
-        unsafe {
-            *outbound_tag_buffer = 0;
-        }
-    }
-
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if event.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP flow-summary event pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP flow-summary target buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP flow-summary target written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if outbound_tag_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP flow-summary outbound tag buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if outbound_tag_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP flow-summary outbound tag written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "TCP flow-summary target buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-    if outbound_tag_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "TCP flow-summary outbound tag buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
+    let target = unsafe {
+        OutStrArgs::new(
+            target_buffer,
+            target_buffer_len,
+            target_written,
+            "TCP flow-summary target",
+        )
+    };
+    let outbound_tag = unsafe {
+        OutStrArgs::new(
+            outbound_tag_buffer,
+            outbound_tag_buffer_len,
+            outbound_tag_written,
+            "TCP flow-summary outbound tag",
+        )
     };
 
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe { ensure_non_null(event, error, "TCP flow-summary event pointer is null")? };
+    let [target, outbound_tag] = unsafe { OutStrArgs::validate([target, outbound_tag], error)? };
+    let core = unsafe { loaded_core(handle, error)? };
+
     let Some(summary) = core.tun().poll_tcp_flow_summary_event() else {
-        return XrayStatus::NoPacket;
+        return Ok(XrayStatus::NoPacket);
     };
 
     unsafe {
@@ -2351,20 +2137,10 @@ unsafe fn xray_tun_poll_tcp_flow_summary_event_inner(
             ms_to_512kib: summary.ms_to_512kib,
             ms_to_1mib: summary.ms_to_1mib,
         };
-        write_c_string_truncated(
-            &summary.target,
-            target_buffer,
-            target_buffer_len,
-            target_written,
-        );
-        write_c_string_truncated(
-            summary.outbound_tag.as_deref().unwrap_or(""),
-            outbound_tag_buffer,
-            outbound_tag_buffer_len,
-            outbound_tag_written,
-        );
+        target.write(&summary.target);
+        outbound_tag.write(summary.outbound_tag.as_deref().unwrap_or(""));
     }
-    XrayStatus::Ok
+    Ok(XrayStatus::Ok)
 }
 
 /// Polls one debug-only TCP open-error event from the TUN endpoint.
@@ -2411,6 +2187,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_open_error_event(
                 error_message_written,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2429,189 +2206,52 @@ unsafe fn xray_tun_poll_tcp_open_error_event_inner(
     error_message_buffer_len: usize,
     error_message_written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
-
-    if !target_written.is_null() {
-        unsafe {
-            *target_written = 0;
-        }
-    }
-    if !target_buffer.is_null() && target_buffer_len > 0 {
-        unsafe {
-            *target_buffer = 0;
-        }
-    }
-    if !outbound_tag_written.is_null() {
-        unsafe {
-            *outbound_tag_written = 0;
-        }
-    }
-    if !outbound_tag_buffer.is_null() && outbound_tag_buffer_len > 0 {
-        unsafe {
-            *outbound_tag_buffer = 0;
-        }
-    }
-    if !error_message_written.is_null() {
-        unsafe {
-            *error_message_written = 0;
-        }
-    }
-    if !error_message_buffer.is_null() && error_message_buffer_len > 0 {
-        unsafe {
-            *error_message_buffer = 0;
-        }
-    }
-
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if event.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP open-error event pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP open-error target buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP open-error target written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if outbound_tag_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP open-error outbound tag buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if outbound_tag_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP open-error outbound tag written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if error_message_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP open-error message buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if error_message_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP open-error message written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "TCP open-error target buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-    if outbound_tag_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "TCP open-error outbound tag buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-    if error_message_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "TCP open-error message buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
+    let target = unsafe {
+        OutStrArgs::new(
+            target_buffer,
+            target_buffer_len,
+            target_written,
+            "TCP open-error target",
+        )
+    };
+    let outbound_tag = unsafe {
+        OutStrArgs::new(
+            outbound_tag_buffer,
+            outbound_tag_buffer_len,
+            outbound_tag_written,
+            "TCP open-error outbound tag",
+        )
+    };
+    let message = unsafe {
+        OutStrArgs::new(
+            error_message_buffer,
+            error_message_buffer_len,
+            error_message_written,
+            "TCP open-error message",
+        )
     };
 
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe { ensure_non_null(event, error, "TCP open-error event pointer is null")? };
+    let [target, outbound_tag, message] =
+        unsafe { OutStrArgs::validate([target, outbound_tag, message], error)? };
+    let core = unsafe { loaded_core(handle, error)? };
+
     let Some(open_error) = core.tun().poll_tcp_open_error_event() else {
-        return XrayStatus::NoPacket;
+        return Ok(XrayStatus::NoPacket);
     };
 
     unsafe {
         *event = XrayTcpOpenErrorEvent { reserved: 0 };
-        write_c_string_truncated(
-            &open_error.target,
-            target_buffer,
-            target_buffer_len,
-            target_written,
-        );
-        write_c_string_truncated(
-            open_error.outbound_tag.as_deref().unwrap_or(""),
-            outbound_tag_buffer,
-            outbound_tag_buffer_len,
-            outbound_tag_written,
-        );
-        write_c_string_truncated(
-            &open_error.error,
-            error_message_buffer,
-            error_message_buffer_len,
-            error_message_written,
-        );
+        target.write(&open_error.target);
+        outbound_tag.write(open_error.outbound_tag.as_deref().unwrap_or(""));
+        message.write(&open_error.error);
     }
-    XrayStatus::Ok
+    Ok(XrayStatus::Ok)
 }
 
 /// Polls one debug-only TCP remote-write slow event from the TUN endpoint.
@@ -2652,6 +2292,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_remote_write_slow_event(
                 outbound_tag_written,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2667,125 +2308,34 @@ unsafe fn xray_tun_poll_tcp_remote_write_slow_event_inner(
     outbound_tag_buffer_len: usize,
     outbound_tag_written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
-
-    if !target_written.is_null() {
-        unsafe {
-            *target_written = 0;
-        }
-    }
-    if !target_buffer.is_null() && target_buffer_len > 0 {
-        unsafe {
-            *target_buffer = 0;
-        }
-    }
-    if !outbound_tag_written.is_null() {
-        unsafe {
-            *outbound_tag_written = 0;
-        }
-    }
-    if !outbound_tag_buffer.is_null() && outbound_tag_buffer_len > 0 {
-        unsafe {
-            *outbound_tag_buffer = 0;
-        }
-    }
-
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if event.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP remote-write slow event pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP remote-write slow target buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP remote-write slow target written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if outbound_tag_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP remote-write slow outbound tag buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if outbound_tag_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "TCP remote-write slow outbound tag written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "TCP remote-write slow target buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-    if outbound_tag_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "TCP remote-write slow outbound tag buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
+    let target = unsafe {
+        OutStrArgs::new(
+            target_buffer,
+            target_buffer_len,
+            target_written,
+            "TCP remote-write slow target",
+        )
+    };
+    let outbound_tag = unsafe {
+        OutStrArgs::new(
+            outbound_tag_buffer,
+            outbound_tag_buffer_len,
+            outbound_tag_written,
+            "TCP remote-write slow outbound tag",
+        )
     };
 
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe { ensure_non_null(event, error, "TCP remote-write slow event pointer is null")? };
+    let [target, outbound_tag] = unsafe { OutStrArgs::validate([target, outbound_tag], error)? };
+    let core = unsafe { loaded_core(handle, error)? };
+
     let Some(slow_write) = core.tun().poll_tcp_remote_write_slow_event() else {
-        return XrayStatus::NoPacket;
+        return Ok(XrayStatus::NoPacket);
     };
 
     unsafe {
@@ -2794,20 +2344,10 @@ unsafe fn xray_tun_poll_tcp_remote_write_slow_event_inner(
             bytes: slow_write.bytes,
             messages: slow_write.messages,
         };
-        write_c_string_truncated(
-            &slow_write.target,
-            target_buffer,
-            target_buffer_len,
-            target_written,
-        );
-        write_c_string_truncated(
-            slow_write.outbound_tag.as_deref().unwrap_or(""),
-            outbound_tag_buffer,
-            outbound_tag_buffer_len,
-            outbound_tag_written,
-        );
+        target.write(&slow_write.target);
+        outbound_tag.write(slow_write.outbound_tag.as_deref().unwrap_or(""));
     }
-    XrayStatus::Ok
+    Ok(XrayStatus::Ok)
 }
 
 /// Polls one debug-only UDP slow-flow event from the TUN endpoint.
@@ -2842,6 +2382,7 @@ pub unsafe extern "C" fn xray_tun_poll_udp_slow_flow_event(
                 target_written,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2853,85 +2394,26 @@ unsafe fn xray_tun_poll_udp_slow_flow_event_inner(
     target_buffer_len: usize,
     target_written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
-
-    if !target_written.is_null() {
-        unsafe {
-            *target_written = 0;
-        }
-    }
-    if !target_buffer.is_null() && target_buffer_len > 0 {
-        unsafe {
-            *target_buffer = 0;
-        }
-    }
-
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if event.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "slow-flow event pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "slow-flow target buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "slow-flow target written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "slow-flow target buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
+    let target = unsafe {
+        OutStrArgs::new(
+            target_buffer,
+            target_buffer_len,
+            target_written,
+            "slow-flow target",
+        )
     };
 
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe { ensure_non_null(event, error, "slow-flow event pointer is null")? };
+    let [target] = unsafe { OutStrArgs::validate([target], error)? };
+    let core = unsafe { loaded_core(handle, error)? };
+
     let Some(slow_flow) = core.tun().poll_udp_slow_flow_event() else {
-        return XrayStatus::NoPacket;
+        return Ok(XrayStatus::NoPacket);
     };
 
     unsafe {
@@ -2940,14 +2422,9 @@ unsafe fn xray_tun_poll_udp_slow_flow_event_inner(
             written_bytes: slow_flow.written_bytes,
             read_bytes: slow_flow.read_bytes,
         };
-        write_c_string_truncated(
-            &slow_flow.target,
-            target_buffer,
-            target_buffer_len,
-            target_written,
-        );
+        target.write(&slow_flow.target);
     }
-    XrayStatus::Ok
+    Ok(XrayStatus::Ok)
 }
 
 /// Polls one debug-only UDP response-gap event from the TUN endpoint.
@@ -2982,6 +2459,7 @@ pub unsafe extern "C" fn xray_tun_poll_udp_response_gap_event(
                 target_written,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2993,85 +2471,26 @@ unsafe fn xray_tun_poll_udp_response_gap_event_inner(
     target_buffer_len: usize,
     target_written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
-
-    if !target_written.is_null() {
-        unsafe {
-            *target_written = 0;
-        }
-    }
-    if !target_buffer.is_null() && target_buffer_len > 0 {
-        unsafe {
-            *target_buffer = 0;
-        }
-    }
-
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if event.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "response-gap event pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "response-gap target buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "response-gap target written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "response-gap target buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
+    let target = unsafe {
+        OutStrArgs::new(
+            target_buffer,
+            target_buffer_len,
+            target_written,
+            "response-gap target",
+        )
     };
 
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe { ensure_non_null(event, error, "response-gap event pointer is null")? };
+    let [target] = unsafe { OutStrArgs::validate([target], error)? };
+    let core = unsafe { loaded_core(handle, error)? };
+
     let Some(response_gap) = core.tun().poll_udp_response_gap_event() else {
-        return XrayStatus::NoPacket;
+        return Ok(XrayStatus::NoPacket);
     };
 
     unsafe {
@@ -3080,14 +2499,9 @@ unsafe fn xray_tun_poll_udp_response_gap_event_inner(
             written_bytes: response_gap.written_bytes,
             read_bytes: response_gap.read_bytes,
         };
-        write_c_string_truncated(
-            &response_gap.target,
-            target_buffer,
-            target_buffer_len,
-            target_written,
-        );
+        target.write(&response_gap.target);
     }
-    XrayStatus::Ok
+    Ok(XrayStatus::Ok)
 }
 
 /// Polls one debug-only UDP QUIC-blocked event from the TUN endpoint.
@@ -3122,6 +2536,7 @@ pub unsafe extern "C" fn xray_tun_poll_udp_quic_blocked_event(
                 target_written,
                 error,
             )
+            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -3133,99 +2548,35 @@ unsafe fn xray_tun_poll_udp_quic_blocked_event_inner(
     target_buffer_len: usize,
     target_written: *mut usize,
     error: *mut *mut XrayError,
-) -> XrayStatus {
+) -> FfiResult {
     unsafe {
         clear_error(error);
     }
-
-    if !target_written.is_null() {
-        unsafe {
-            *target_written = 0;
-        }
-    }
-    if !target_buffer.is_null() && target_buffer_len > 0 {
-        unsafe {
-            *target_buffer = 0;
-        }
-    }
-
-    if handle.is_null() {
-        unsafe {
-            set_error(error, XrayStatus::NullArgument, "core handle is null");
-        }
-        return XrayStatus::NullArgument;
-    }
-    if event.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "QUIC-blocked event pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "QUIC-blocked target buffer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_written.is_null() {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::NullArgument,
-                "QUIC-blocked target written pointer is null",
-            );
-        }
-        return XrayStatus::NullArgument;
-    }
-    if target_buffer_len == 0 {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::BufferTooSmall,
-                "QUIC-blocked target buffer length is zero",
-            );
-        }
-        return XrayStatus::BufferTooSmall;
-    }
-
-    // Shared access: data-path entry points may run concurrently with each
-    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
-    let handle = unsafe { &*handle };
-    let Some(core) = handle.core.as_ref() else {
-        unsafe {
-            set_error(
-                error,
-                XrayStatus::CoreNotLoaded,
-                "core config is not loaded",
-            );
-        }
-        return XrayStatus::CoreNotLoaded;
+    let target = unsafe {
+        OutStrArgs::new(
+            target_buffer,
+            target_buffer_len,
+            target_written,
+            "QUIC-blocked target",
+        )
     };
 
+    let handle = unsafe { shared_handle(handle, error)? };
+    unsafe { ensure_non_null(event, error, "QUIC-blocked event pointer is null")? };
+    let [target] = unsafe { OutStrArgs::validate([target], error)? };
+    let core = unsafe { loaded_core(handle, error)? };
+
     let Some(blocked) = core.tun().poll_udp_quic_blocked_event() else {
-        return XrayStatus::NoPacket;
+        return Ok(XrayStatus::NoPacket);
     };
 
     unsafe {
         *event = XrayUdpQuicBlockedEvent {
             bytes: blocked.bytes,
         };
-        write_c_string_truncated(
-            &blocked.target,
-            target_buffer,
-            target_buffer_len,
-            target_written,
-        );
+        target.write(&blocked.target);
     }
-    XrayStatus::Ok
+    Ok(XrayStatus::Ok)
 }
 
 /// Writes a TUN packet counter snapshot to `stats`.
@@ -3514,18 +2865,202 @@ unsafe fn free_error(error: *mut XrayError) {
     }
 }
 
-unsafe fn write_c_string_truncated(
-    value: &str,
-    buffer: *mut c_char,
-    buffer_len: usize,
+/// Outcome of a fallible FFI body. `Err` carries a status that has already
+/// been reported through [`set_error`] and lets the body bail out with `?`;
+/// `Ok` carries the status of the completed call. Both collapse to the same
+/// `XrayStatus` at the C boundary.
+type FfiResult = Result<XrayStatus, XrayStatus>;
+
+/// Dereferences a caller-supplied core handle for shared, data-path access.
+///
+/// # Safety
+///
+/// `handle` must either be null or a pointer returned by `xray_core_new` that
+/// has not been freed and is not freed while the returned reference is alive.
+/// `error` must be null or point to an initialized `*mut XrayError`.
+unsafe fn shared_handle<'a>(
+    handle: *mut XrayCoreHandle,
+    error: *mut *mut XrayError,
+) -> Result<&'a XrayCoreHandle, XrayStatus> {
+    if handle.is_null() {
+        unsafe {
+            set_error(error, XrayStatus::NullArgument, "core handle is null");
+        }
+        return Err(XrayStatus::NullArgument);
+    }
+
+    // Shared access: data-path entry points may run concurrently with each
+    // other (Swift pump push/poll threads); only lifecycle calls take `&mut`.
+    Ok(unsafe { &*handle })
+}
+
+/// Returns the loaded core behind `handle`, reporting `CoreNotLoaded` when no
+/// config has been loaded yet.
+///
+/// # Safety
+///
+/// `error` must be null or point to an initialized `*mut XrayError`.
+unsafe fn loaded_core(
+    handle: &XrayCoreHandle,
+    error: *mut *mut XrayError,
+) -> Result<&Core, XrayStatus> {
+    match handle.core.as_ref() {
+        Some(core) => Ok(core),
+        None => {
+            unsafe {
+                set_error(
+                    error,
+                    XrayStatus::CoreNotLoaded,
+                    "core config is not loaded",
+                );
+            }
+            Err(XrayStatus::CoreNotLoaded)
+        }
+    }
+}
+
+/// Reports `NullArgument` with `message` when a caller-provided out pointer is
+/// null.
+///
+/// # Safety
+///
+/// `error` must be null or point to an initialized `*mut XrayError`.
+unsafe fn ensure_non_null<T>(
+    ptr: *mut T,
+    error: *mut *mut XrayError,
+    message: &str,
+) -> Result<(), XrayStatus> {
+    if ptr.is_null() {
+        unsafe {
+            set_error(error, XrayStatus::NullArgument, message);
+        }
+        return Err(XrayStatus::NullArgument);
+    }
+    Ok(())
+}
+
+/// A caller-provided output string buffer exactly as received over the C ABI,
+/// before validation. `name` prefixes the error messages, e.g.
+/// `"TCP open-error target"` yields `"TCP open-error target buffer is null"`.
+struct OutStrArgs<'a> {
+    ptr: *mut c_char,
+    len: usize,
     written: *mut usize,
-) {
-    let bytes = value.as_bytes();
-    let copy_len = bytes.len().min(buffer_len.saturating_sub(1));
-    unsafe {
-        ptr::copy_nonoverlapping(bytes.as_ptr(), buffer.cast::<u8>(), copy_len);
-        *buffer.add(copy_len) = 0;
-        *written = copy_len;
+    name: &'a str,
+}
+
+impl<'a> OutStrArgs<'a> {
+    /// Captures the raw arguments and resets whichever out-params the caller
+    /// did provide (`*written = 0`, leading NUL) so they hold well-defined
+    /// values no matter which later check fails.
+    ///
+    /// # Safety
+    ///
+    /// `written` must be null or point to one writable `usize`; `ptr` must be
+    /// null or point to `len` writable bytes.
+    unsafe fn new(ptr: *mut c_char, len: usize, written: *mut usize, name: &'a str) -> Self {
+        if !written.is_null() {
+            unsafe {
+                *written = 0;
+            }
+        }
+        if !ptr.is_null() && len > 0 {
+            unsafe {
+                *ptr = 0;
+            }
+        }
+        Self {
+            ptr,
+            len,
+            written,
+            name,
+        }
+    }
+
+    /// Validates `args` in the order the C ABI has always reported them: every
+    /// null check (buffer, then written pointer, argument by argument) before
+    /// any zero-length check. Returns the validated buffers in the same order.
+    ///
+    /// # Safety
+    ///
+    /// `error` must be null or point to an initialized `*mut XrayError`.
+    unsafe fn validate<const N: usize>(
+        args: [Self; N],
+        error: *mut *mut XrayError,
+    ) -> Result<[OutStrBuf; N], XrayStatus> {
+        for arg in &args {
+            if arg.ptr.is_null() {
+                unsafe {
+                    set_error(
+                        error,
+                        XrayStatus::NullArgument,
+                        format!("{} buffer is null", arg.name),
+                    );
+                }
+                return Err(XrayStatus::NullArgument);
+            }
+            if arg.written.is_null() {
+                unsafe {
+                    set_error(
+                        error,
+                        XrayStatus::NullArgument,
+                        format!("{} written pointer is null", arg.name),
+                    );
+                }
+                return Err(XrayStatus::NullArgument);
+            }
+        }
+        for arg in &args {
+            if arg.len == 0 {
+                unsafe {
+                    set_error(
+                        error,
+                        XrayStatus::BufferTooSmall,
+                        format!("{} buffer length is zero", arg.name),
+                    );
+                }
+                return Err(XrayStatus::BufferTooSmall);
+            }
+        }
+        Ok(args.map(|arg| OutStrBuf {
+            ptr: arg.ptr,
+            len: arg.len,
+            written: arg.written,
+        }))
+    }
+}
+
+/// A validated caller-provided output string buffer: `ptr` and `written` are
+/// non-null and `len > 0`. Only [`OutStrArgs::validate`] constructs one.
+struct OutStrBuf {
+    ptr: *mut c_char,
+    len: usize,
+    written: *mut usize,
+}
+
+impl OutStrBuf {
+    /// Writes `value` as a NUL-terminated C string, truncating on a UTF-8
+    /// character boundary when it does not fit, and stores the number of bytes
+    /// copied (excluding the terminator) in `*written`. A zero-length buffer
+    /// is left untouched, since not even the terminator fits.
+    ///
+    /// # Safety
+    ///
+    /// `self.ptr` must be valid for `self.len` byte writes and `self.written`
+    /// for one `usize` write, and neither may overlap `value`.
+    unsafe fn write(&self, value: &str) {
+        if self.len == 0 {
+            return;
+        }
+        let mut copy_len = value.len().min(self.len - 1);
+        while !value.is_char_boundary(copy_len) {
+            copy_len -= 1;
+        }
+        unsafe {
+            ptr::copy_nonoverlapping(value.as_ptr(), self.ptr.cast::<u8>(), copy_len);
+            *self.ptr.add(copy_len) = 0;
+            *self.written = copy_len;
+        }
     }
 }
 
@@ -3612,11 +3147,13 @@ mod tests {
     use std::ffi::CStr;
     use std::ptr;
 
+    use libc::c_char;
+
     use super::{
         ffi_panic_message, ffi_status, free_error,
         runtime_worker_threads_for_available_parallelism, xray_core_free, xray_core_new,
-        xray_core_set_dns_bootstrap_mode, DnsBootstrapMode, XrayDnsBootstrapMode, XrayError,
-        XrayStatus,
+        xray_core_set_dns_bootstrap_mode, DnsBootstrapMode, OutStrArgs, OutStrBuf,
+        XrayDnsBootstrapMode, XrayError, XrayStatus,
     };
 
     #[test]
@@ -3665,6 +3202,138 @@ mod tests {
         );
 
         unsafe { xray_core_free(handle) };
+    }
+
+    #[test]
+    fn out_str_buf_write_copies_value_that_fits() {
+        let mut buffer = [0x7f as c_char; 8];
+        let mut written = usize::MAX;
+        let buf = OutStrBuf {
+            ptr: buffer.as_mut_ptr(),
+            len: buffer.len(),
+            written: &mut written,
+        };
+
+        unsafe { buf.write("héllo") };
+
+        assert_eq!(written, 6);
+        let value = unsafe { CStr::from_ptr(buffer.as_ptr()) }.to_str().unwrap();
+        assert_eq!(value, "héllo");
+        assert_eq!(buffer[7], 0x7f, "bytes past the terminator stay untouched");
+    }
+
+    #[test]
+    fn out_str_buf_write_truncates_on_utf8_boundary() {
+        let mut buffer = [0x7f as c_char; 3];
+        let mut written = usize::MAX;
+        let buf = OutStrBuf {
+            ptr: buffer.as_mut_ptr(),
+            len: buffer.len(),
+            written: &mut written,
+        };
+
+        // Two payload bytes would fit, but that would split the two-byte `é`.
+        unsafe { buf.write("héllo") };
+
+        assert_eq!(written, 1);
+        assert_eq!(buffer[0], b'h' as c_char);
+        assert_eq!(buffer[1], 0);
+        assert_eq!(buffer[2], 0x7f);
+    }
+
+    #[test]
+    fn out_str_buf_write_to_zero_length_buffer_is_noop() {
+        let mut buffer = [0x7f as c_char; 1];
+        let mut written = 42usize;
+        let buf = OutStrBuf {
+            ptr: buffer.as_mut_ptr(),
+            len: 0,
+            written: &mut written,
+        };
+
+        unsafe { buf.write("abc") };
+
+        assert_eq!(written, 42);
+        assert_eq!(buffer[0], 0x7f);
+    }
+
+    #[test]
+    fn out_str_args_new_resets_provided_out_params_only() {
+        let mut buffer = [0x7f as c_char; 2];
+        let mut written = 42usize;
+
+        let _ = unsafe { OutStrArgs::new(buffer.as_mut_ptr(), 0, &mut written, "test") };
+        assert_eq!(written, 0);
+        assert_eq!(buffer[0], 0x7f, "zero-length buffers are not written to");
+
+        let _ = unsafe { OutStrArgs::new(buffer.as_mut_ptr(), 2, ptr::null_mut(), "test") };
+        assert_eq!(buffer[0], 0);
+        assert_eq!(buffer[1], 0x7f);
+    }
+
+    #[test]
+    fn out_str_args_validate_reports_every_null_before_any_zero_length() {
+        let mut error: *mut XrayError = ptr::null_mut();
+        let mut target = [0 as c_char; 4];
+        let mut target_written = 0usize;
+        let mut outbound_written = 0usize;
+
+        let result = unsafe {
+            OutStrArgs::validate(
+                [
+                    OutStrArgs::new(target.as_mut_ptr(), 0, &mut target_written, "test target"),
+                    OutStrArgs::new(
+                        ptr::null_mut(),
+                        4,
+                        &mut outbound_written,
+                        "test outbound tag",
+                    ),
+                ],
+                &mut error,
+            )
+        };
+
+        assert!(matches!(result, Err(XrayStatus::NullArgument)));
+        let message = unsafe { CStr::from_ptr((*error).message) }
+            .to_str()
+            .unwrap();
+        assert_eq!(message, "test outbound tag buffer is null");
+        unsafe {
+            free_error(error);
+        }
+    }
+
+    #[test]
+    fn out_str_args_validate_reports_zero_length_in_argument_order() {
+        let mut error: *mut XrayError = ptr::null_mut();
+        let mut target = [0 as c_char; 4];
+        let mut outbound = [0 as c_char; 4];
+        let mut target_written = 0usize;
+        let mut outbound_written = 0usize;
+
+        let result = unsafe {
+            OutStrArgs::validate(
+                [
+                    OutStrArgs::new(target.as_mut_ptr(), 4, &mut target_written, "test target"),
+                    OutStrArgs::new(
+                        outbound.as_mut_ptr(),
+                        0,
+                        &mut outbound_written,
+                        "test outbound tag",
+                    ),
+                ],
+                &mut error,
+            )
+        };
+
+        assert!(matches!(result, Err(XrayStatus::BufferTooSmall)));
+        let message = unsafe { CStr::from_ptr((*error).message) }
+            .to_str()
+            .unwrap();
+        assert_eq!(message, "test outbound tag buffer length is zero");
+        unsafe {
+            free_error(error);
+        }
     }
 
     #[test]

--- a/crates/xray-ffi/src/lib.rs
+++ b/crates/xray-ffi/src/lib.rs
@@ -1726,9 +1726,8 @@ pub unsafe extern "C" fn xray_tun_poll_packet(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_packet_inner(handle, buffer, buffer_len, written, error)
-                .unwrap_or_else(|status| status)
         })
     }
 }
@@ -1840,7 +1839,7 @@ pub unsafe extern "C" fn xray_tun_poll_packets(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_packets_inner(
                 handle,
                 buffer,
@@ -1851,7 +1850,6 @@ pub unsafe extern "C" fn xray_tun_poll_packets(
                 wait_ms,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -1986,7 +1984,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_slow_flow_event(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_tcp_slow_flow_event_inner(
                 handle,
                 event,
@@ -1995,7 +1993,6 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_slow_flow_event(
                 target_written,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2066,7 +2063,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_flow_summary_event(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_tcp_flow_summary_event_inner(
                 handle,
                 event,
@@ -2078,7 +2075,6 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_flow_summary_event(
                 outbound_tag_written,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2172,7 +2168,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_open_error_event(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_tcp_open_error_event_inner(
                 handle,
                 event,
@@ -2187,7 +2183,6 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_open_error_event(
                 error_message_written,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2280,7 +2275,7 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_remote_write_slow_event(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_tcp_remote_write_slow_event_inner(
                 handle,
                 event,
@@ -2292,7 +2287,6 @@ pub unsafe extern "C" fn xray_tun_poll_tcp_remote_write_slow_event(
                 outbound_tag_written,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2373,7 +2367,7 @@ pub unsafe extern "C" fn xray_tun_poll_udp_slow_flow_event(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_udp_slow_flow_event_inner(
                 handle,
                 event,
@@ -2382,7 +2376,6 @@ pub unsafe extern "C" fn xray_tun_poll_udp_slow_flow_event(
                 target_written,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2450,7 +2443,7 @@ pub unsafe extern "C" fn xray_tun_poll_udp_response_gap_event(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_udp_response_gap_event_inner(
                 handle,
                 event,
@@ -2459,7 +2452,6 @@ pub unsafe extern "C" fn xray_tun_poll_udp_response_gap_event(
                 target_written,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -2527,7 +2519,7 @@ pub unsafe extern "C" fn xray_tun_poll_udp_quic_blocked_event(
     error: *mut *mut XrayError,
 ) -> XrayStatus {
     unsafe {
-        ffi_status(error, || {
+        ffi_result_status(error, || {
             xray_tun_poll_udp_quic_blocked_event_inner(
                 handle,
                 event,
@@ -2536,7 +2528,6 @@ pub unsafe extern "C" fn xray_tun_poll_udp_quic_blocked_event(
                 target_written,
                 error,
             )
-            .unwrap_or_else(|status| status)
         })
     }
 }
@@ -3062,6 +3053,20 @@ impl OutStrBuf {
             *self.written = copy_len;
         }
     }
+}
+
+/// [`ffi_status`] for bodies that bail out with `?`. Both arms of an
+/// [`FfiResult`] carry a status that has already been reported, so they
+/// collapse to the single status the C ABI returns.
+///
+/// # Safety
+///
+/// `error` must be null or point to an initialized `*mut XrayError`.
+unsafe fn ffi_result_status(
+    error: *mut *mut XrayError,
+    action: impl FnOnce() -> FfiResult,
+) -> XrayStatus {
+    unsafe { ffi_status(error, || action().unwrap_or_else(|status| status)) }
 }
 
 unsafe fn ffi_status(

--- a/crates/xray-ffi/tests/ffi_tests.rs
+++ b/crates/xray-ffi/tests/ffi_tests.rs
@@ -1811,6 +1811,452 @@ fn ffi_tun_poll_tcp_open_error_event_reports_no_packet() {
 }
 
 #[test]
+fn ffi_tun_poll_tcp_open_error_event_rejects_null_handle_before_other_arguments() {
+    let mut err = std::ptr::null_mut();
+    let mut target = [0x7f_i8; 8];
+    let mut written = 7usize;
+
+    // Every other argument is also invalid; the handle check must still win.
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            target.as_mut_ptr(),
+            0,
+            &mut written,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            &mut err,
+        )
+    };
+
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(&mut err, XrayStatus::NullArgument, "core handle is null");
+    assert_eq!(written, 0, "written is reset even when validation fails");
+    assert_eq!(target[0], 0x7f, "zero-length buffers are never written to");
+}
+
+#[test]
+fn ffi_tun_poll_tcp_open_error_event_rejects_null_event_pointer() {
+    let mut err = std::ptr::null_mut();
+    let core = loaded_core(&mut err);
+    let mut target = [0x7f_i8; 8];
+    let mut outbound = [0x7f_i8; 8];
+    let mut message = [0x7f_i8; 8];
+    let mut written = 7usize;
+    let mut outbound_written = 9usize;
+    let mut message_written = 11usize;
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            std::ptr::null_mut(),
+            target.as_mut_ptr(),
+            target.len(),
+            &mut written,
+            outbound.as_mut_ptr(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            &mut message_written,
+            &mut err,
+        )
+    };
+
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "TCP open-error event pointer is null",
+    );
+    // Reset happened for every provided out-param before the failing check.
+    assert_eq!((written, outbound_written, message_written), (0, 0, 0));
+    assert_eq!((target[0], outbound[0], message[0]), (0, 0, 0));
+    assert_eq!((target[1], outbound[1], message[1]), (0x7f, 0x7f, 0x7f));
+
+    unsafe {
+        xray_core_free(core);
+    }
+}
+
+#[test]
+fn ffi_tun_poll_tcp_open_error_event_rejects_null_string_arguments_in_order() {
+    let mut err = std::ptr::null_mut();
+    let core = loaded_core(&mut err);
+    let mut event = XrayTcpOpenErrorEvent::default();
+    let mut target = [0_i8; 8];
+    let mut outbound = [0_i8; 8];
+    let mut message = [0_i8; 8];
+    let mut written = 0usize;
+    let mut outbound_written = 0usize;
+    let mut message_written = 0usize;
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            std::ptr::null_mut(),
+            target.len(),
+            std::ptr::null_mut(),
+            outbound.as_mut_ptr(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "TCP open-error target buffer is null",
+    );
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            target.len(),
+            std::ptr::null_mut(),
+            outbound.as_mut_ptr(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "TCP open-error target written pointer is null",
+    );
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            target.len(),
+            &mut written,
+            std::ptr::null_mut(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            std::ptr::null_mut(),
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "TCP open-error outbound tag buffer is null",
+    );
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            target.len(),
+            &mut written,
+            outbound.as_mut_ptr(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            std::ptr::null_mut(),
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "TCP open-error message written pointer is null",
+    );
+
+    unsafe {
+        xray_core_free(core);
+    }
+}
+
+#[test]
+fn ffi_tun_poll_tcp_open_error_event_checks_all_nulls_before_zero_lengths() {
+    let mut err = std::ptr::null_mut();
+    let core = loaded_core(&mut err);
+    let mut event = XrayTcpOpenErrorEvent::default();
+    let mut target = [0_i8; 8];
+    let mut message = [0_i8; 8];
+    let mut written = 0usize;
+    let mut outbound_written = 0usize;
+    let mut message_written = 0usize;
+
+    // A zero-length target comes first in parameter order, but a null
+    // outbound-tag buffer must still be reported ahead of it.
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            0,
+            &mut written,
+            std::ptr::null_mut(),
+            8,
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "TCP open-error outbound tag buffer is null",
+    );
+
+    unsafe {
+        xray_core_free(core);
+    }
+}
+
+#[test]
+fn ffi_tun_poll_tcp_open_error_event_rejects_zero_lengths_in_order() {
+    let mut err = std::ptr::null_mut();
+    let core = loaded_core(&mut err);
+    let mut event = XrayTcpOpenErrorEvent::default();
+    let mut target = [0_i8; 8];
+    let mut outbound = [0_i8; 8];
+    let mut message = [0_i8; 8];
+    let mut written = 0usize;
+    let mut outbound_written = 0usize;
+    let mut message_written = 0usize;
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            0,
+            &mut written,
+            outbound.as_mut_ptr(),
+            0,
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            0,
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::BufferTooSmall);
+    assert_error(
+        &mut err,
+        XrayStatus::BufferTooSmall,
+        "TCP open-error target buffer length is zero",
+    );
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            target.len(),
+            &mut written,
+            outbound.as_mut_ptr(),
+            0,
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            0,
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::BufferTooSmall);
+    assert_error(
+        &mut err,
+        XrayStatus::BufferTooSmall,
+        "TCP open-error outbound tag buffer length is zero",
+    );
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            target.len(),
+            &mut written,
+            outbound.as_mut_ptr(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            0,
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::BufferTooSmall);
+    assert_error(
+        &mut err,
+        XrayStatus::BufferTooSmall,
+        "TCP open-error message buffer length is zero",
+    );
+
+    unsafe {
+        xray_core_free(core);
+    }
+}
+
+#[test]
+fn ffi_tun_poll_tcp_open_error_event_validates_arguments_before_core_state() {
+    let mut err = std::ptr::null_mut();
+    let core = unsafe { xray_core_new(&mut err) };
+    let mut event = XrayTcpOpenErrorEvent::default();
+    let mut target = [0_i8; 8];
+    let mut outbound = [0_i8; 8];
+    let mut message = [0_i8; 8];
+    let mut written = 0usize;
+    let mut outbound_written = 0usize;
+    let mut message_written = 0usize;
+
+    // No config loaded, but an invalid buffer argument is reported first.
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            0,
+            &mut written,
+            outbound.as_mut_ptr(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::BufferTooSmall);
+    assert_error(
+        &mut err,
+        XrayStatus::BufferTooSmall,
+        "TCP open-error target buffer length is zero",
+    );
+
+    let status = unsafe {
+        xray_tun_poll_tcp_open_error_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            target.len(),
+            &mut written,
+            outbound.as_mut_ptr(),
+            outbound.len(),
+            &mut outbound_written,
+            message.as_mut_ptr(),
+            message.len(),
+            &mut message_written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::CoreNotLoaded);
+    assert_error(
+        &mut err,
+        XrayStatus::CoreNotLoaded,
+        "core config is not loaded",
+    );
+
+    unsafe {
+        xray_core_free(core);
+    }
+}
+
+#[test]
+fn ffi_tun_poll_udp_slow_flow_event_rejects_null_target_written_pointer() {
+    let mut err = std::ptr::null_mut();
+    let core = loaded_core(&mut err);
+    let mut event = XrayUdpSlowFlowEvent::default();
+    let mut target = [0x7f_i8; 8];
+
+    let status = unsafe {
+        xray_tun_poll_udp_slow_flow_event(
+            core,
+            &mut event,
+            target.as_mut_ptr(),
+            target.len(),
+            std::ptr::null_mut(),
+            &mut err,
+        )
+    };
+
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "slow-flow target written pointer is null",
+    );
+    assert_eq!(target[0], 0, "leading NUL is written before validation");
+
+    unsafe {
+        xray_core_free(core);
+    }
+}
+
+#[test]
+fn ffi_tun_poll_packet_rejects_null_buffer_and_written_pointer() {
+    let mut err = std::ptr::null_mut();
+    let core = loaded_core(&mut err);
+    let mut buffer = [0_u8; 16];
+    let mut written = 7usize;
+
+    let status = unsafe {
+        xray_tun_poll_packet(
+            core,
+            std::ptr::null_mut(),
+            buffer.len(),
+            &mut written,
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(&mut err, XrayStatus::NullArgument, "packet buffer is null");
+    assert_eq!(written, 0);
+
+    let status = unsafe {
+        xray_tun_poll_packet(
+            core,
+            buffer.as_mut_ptr(),
+            buffer.len(),
+            std::ptr::null_mut(),
+            &mut err,
+        )
+    };
+    assert_eq!(status, XrayStatus::NullArgument);
+    assert_error(
+        &mut err,
+        XrayStatus::NullArgument,
+        "written pointer is null",
+    );
+
+    unsafe {
+        xray_core_free(core);
+    }
+}
+
+#[test]
 fn ffi_tun_poll_tcp_remote_write_slow_event_reports_no_packet() {
     let mut err = std::ptr::null_mut();
     let core = loaded_core(&mut err);


### PR DESCRIPTION
## Summary

Nine `xray_tun_poll_*_inner` functions shared one hand-copied skeleton: `clear_error` → reset every out-param → null-check every pointer with its own message → reject zero-length buffers → dereference the handle → check the core is loaded → poll → write. That was 133 `NullArgument` sites and ~1100 lines of `unsafe` inside the ten-argument event pollers, where each copy is a chance to drop a check, reset the wrong out-param, or write a terminator past the end of a buffer. This PR turns those invariants into types.

- **Output buffers** — `OutStrArgs { ptr, len, written, name }` captures one caller-provided string buffer exactly as it arrives over the C ABI; `OutStrArgs::new` performs the reset step (`*written = 0`, leading NUL) for whichever out-params the caller did provide, so they hold defined values no matter which later check fails. `OutStrArgs::validate<const N>([args; N])` then checks every buffer's null pointers first and all zero lengths second, in argument order — the precedence the ABI has always reported — and returns `[OutStrBuf; N]`. `OutStrBuf` is constructible only through `validate`, so `ptr != null`, `written != null` and `len > 0` are type invariants rather than per-function copies. `name` prefixes the messages (`"TCP open-error target"` → `"TCP open-error target buffer is null"`), which is exactly the pattern every message already followed.
- **`OutStrBuf::write`** replaces `write_c_string_truncated` and fixes its two latent bugs: a zero-length buffer is left untouched (the old helper wrote the NUL terminator one byte out of bounds — unreachable through the public API because all twelve call sites were guarded upstream, now impossible by construction), and truncation backs off to a UTF-8 character boundary instead of cutting a code point in half. `target` and `outbound_tag` carry user-visible host names and can be non-ASCII.
- **Handle and core** — `shared_handle` (null → `NullArgument`, carrying the shared-access comment on the deref), `loaded_core` (`None` → `CoreNotLoaded`) and `ensure_non_null` for the remaining out-pointers. Deliberately not one `with_core`: a helper doing both checks in a single call cannot keep the `handle → event → buffers → CoreNotLoaded` ordering, since the event and buffer checks sit between them.
- **Control flow** — `_inner` bodies return `FfiResult = Result<XrayStatus, XrayStatus>`, where `Err` carries a status already reported through `set_error`, so every check becomes a `?`. `ffi_result_status` collapses both arms inside the `catch_unwind` wrapper, leaving each `extern "C"` function as just the call to its `_inner`.

A body now reads `clear_error` → `OutStrArgs::new` per buffer → `shared_handle(..)?` → `ensure_non_null(event, ..)?` → `let [target, outbound_tag] = OutStrArgs::validate([..], error)?` → `loaded_core(..)?` → poll → `target.write(..)`.

Result: `NullArgument` sites 133 → 57, poll-function bodies 1145 → 487 lines, `#[allow(clippy::too_many_arguments)]` unchanged at 4. `grep -rn "write_c_string_truncated" crates` is empty. The remaining 57 sites are in functions this PR does not touch — `xray_tun_stats`, `xray_tun_push_packet`, `xray_core_config_warnings` and the setters — which are candidates for the same helpers in a follow-up.

## Behaviour

- Error message texts, status codes, check ordering, `#[repr(C)]` types and every `extern "C"` signature are unchanged. All 43 message literals in the old poll functions were diffed against the new ones, generated and literal.
- Two intentional changes, both in `OutStrBuf::write`: a zero-length buffer is a no-op instead of an out-of-bounds terminator write, and truncation lands on a UTF-8 character boundary instead of splitting a code point. Neither is reachable as a behaviour change for a caller that passes a non-empty ASCII-only buffer, which is every case the current tests covered.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --exclude xray-rust-fuzz --all-targets --all-features -- -D warnings -W clippy::perf -W clippy::suspicious` — clean (fuzz crate excluded only because `libfuzzer-sys` can't build its C++ on the dev machine; CI runs the full set)
- `cargo test -p xray-ffi` — 111 passed, 0 failed, 0 ignored (11 lib unit + 72 `ffi_tests` + 28 `mobile_artifacts_tests`)

New coverage: six unit tests on the helpers — whole-value copy, `"héllo"` into a 3-byte buffer writing `"h"` + NUL with `written == 1`, the zero-length no-op, `OutStrArgs::new` resetting only provided out-params and never touching a zero-length buffer, a later null reported before an earlier zero length, and zero lengths reported in argument order. Eight FFI tests pin the ABI-visible contract: for `xray_tun_poll_tcp_open_error_event` a null handle wins over every other bad argument (with the out-params still reset), each null buffer/written and each zero-length message in order, null-before-zero-length precedence, and argument errors ahead of `CoreNotLoaded` on an unloaded core; plus null `target_written` for `udp_slow_flow_event` and null buffer/written for `poll_packet`.

UTF-8 truncation is covered by unit tests only: injecting a real event with a non-ASCII target through the public FFI surface would need a live connection to a non-ASCII host, which the test harness does not provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)