### PR TITLE
perf(tun): carve inbound fd packets out of a shared read arena

### DIFF
--- a/crates/xray-core-rs/src/tun_fd.rs
+++ b/crates/xray-core-rs/src/tun_fd.rs
@@ -62,7 +62,7 @@ mod platform {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use bytes::Bytes;
+    use bytes::{Buf, BufMut, Bytes, BytesMut};
     use tokio::io::unix::AsyncFd;
     use tokio::sync::watch;
     use tokio::task::JoinHandle;
@@ -73,6 +73,11 @@ mod platform {
 
     const DARWIN_UTUN_HEADER_LEN: usize = 4;
     const TUN_FD_WRITE_BATCH_MAX_PACKETS: usize = 128;
+    /// Smallest read arena. One allocation serves roughly 40 MTU-sized
+    /// packets, and never exceeds the single maximum-size packet buffer the
+    /// per-packet path used to allocate, which bounds what one long-lived
+    /// packet can pin. A larger MTU raises it to hold one whole read.
+    const TUN_FD_READ_ARENA_MIN: usize = 64 * 1024;
 
     pub struct TunFdRuntime {
         shutdown: watch::Sender<bool>,
@@ -281,7 +286,7 @@ mod platform {
         mut shutdown: watch::Receiver<bool>,
         packet_format: TunFdPacketFormat,
     ) {
-        let mut buffer = vec![0_u8; read_buffer_len(packet_format)];
+        let mut reader = PacketReader::new(packet_format, tun.mtu());
         let mut consecutive_errors: u32 = 0;
 
         loop {
@@ -291,7 +296,7 @@ mod platform {
                         break;
                     }
                 }
-                packet = read_packet(&fd, packet_format, &mut buffer) => {
+                packet = reader.read_packet(&fd) => {
                     match packet {
                         Ok(Some(packet)) => {
                             consecutive_errors = 0;
@@ -452,40 +457,102 @@ mod platform {
         }
     }
 
-    async fn read_packet(
-        fd: &AsyncFd<TunFd>,
-        packet_format: TunFdPacketFormat,
-        buffer: &mut [u8],
-    ) -> io::Result<Option<Bytes>> {
-        loop {
-            let mut guard = fd.readable().await?;
-            let result = guard.try_io(|inner| {
-                let read = unsafe {
-                    libc::read(
-                        inner.get_ref().as_raw_fd(),
-                        buffer.as_mut_ptr().cast(),
-                        buffer.len(),
-                    )
-                };
-                if read < 0 {
-                    Err(io::Error::last_os_error())
-                } else {
-                    Ok(read as usize)
-                }
-            });
+    /// Carves inbound packets out of a shared arena so a packet reaches the
+    /// queue without a per-packet allocation and without a copy: the read
+    /// lands directly in the arena's spare capacity and the packet is split
+    /// off it, sharing the allocation with its neighbours.
+    struct PacketReader {
+        arena: BytesMut,
+        /// Bytes offered to one `read`: one MTU-sized packet plus the format
+        /// header, plus one byte. That extra byte is what makes an oversized
+        /// packet observable — it comes back one byte over the MTU and
+        /// `push_inbound` rejects it, exactly as it did when the whole
+        /// oversized packet was read and rejected.
+        single_read: usize,
+        arena_len: usize,
+        header_len: usize,
+    }
 
-            match result {
-                Ok(Ok(0)) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        "tun fd reached EOF",
-                    ))
-                }
-                Ok(Ok(len)) => return Ok(decode_packet(packet_format, &buffer[..len])),
-                Ok(Err(err)) if err.kind() == io::ErrorKind::WouldBlock => continue,
-                Ok(Err(err)) => return Err(err),
-                Err(_) => continue,
+    impl PacketReader {
+        fn new(packet_format: TunFdPacketFormat, mtu: usize) -> Self {
+            let header_len = match packet_format {
+                TunFdPacketFormat::RawIp => 0,
+                TunFdPacketFormat::DarwinUtun => DARWIN_UTUN_HEADER_LEN,
+            };
+            let single_read = mtu
+                .min(MAX_IP_PACKET_SIZE)
+                .saturating_add(header_len)
+                .saturating_add(1);
+            let arena_len = single_read.max(TUN_FD_READ_ARENA_MIN);
+            Self {
+                arena: BytesMut::with_capacity(arena_len),
+                single_read,
+                arena_len,
+                header_len,
             }
+        }
+
+        /// Reads one packet, returning `None` for a read that carries no
+        /// payload once the format header is stripped.
+        async fn read_packet(&mut self, fd: &AsyncFd<TunFd>) -> io::Result<Option<Bytes>> {
+            loop {
+                // A packet is split off whole, so the arena is always empty
+                // here and its capacity is what is left of the allocation.
+                // The exhausted arena is released rather than recycled: the
+                // packets carved from it keep it alive until the stack has
+                // consumed them, so it is never exclusively owned at this
+                // point and `try_reclaim` would always fail.
+                if self.arena.capacity() < self.single_read {
+                    self.arena = BytesMut::with_capacity(self.arena_len);
+                }
+
+                let mut guard = fd.readable().await?;
+                let spare = self.arena.spare_capacity_mut();
+                let result = guard.try_io(|inner| {
+                    // SAFETY: the arena reserved at least `self.single_read`
+                    // spare bytes above, and nothing else references them
+                    // until they are split off.
+                    let read = unsafe {
+                        libc::read(
+                            inner.get_ref().as_raw_fd(),
+                            spare.as_mut_ptr().cast(),
+                            self.single_read,
+                        )
+                    };
+                    if read < 0 {
+                        Err(io::Error::last_os_error())
+                    } else {
+                        Ok(read as usize)
+                    }
+                });
+
+                match result {
+                    Ok(Ok(0)) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "tun fd reached EOF",
+                        ))
+                    }
+                    Ok(Ok(len)) => return Ok(self.split_packet(len)),
+                    Ok(Err(err)) if err.kind() == io::ErrorKind::WouldBlock => continue,
+                    Ok(Err(err)) => return Err(err),
+                    Err(_) => continue,
+                }
+            }
+        }
+
+        /// Splits the `len` bytes just read off the arena and strips the
+        /// format header.
+        fn split_packet(&mut self, len: usize) -> Option<Bytes> {
+            // SAFETY: `read` reported `len` bytes written into the spare
+            // capacity, so they are initialized.
+            unsafe { self.arena.advance_mut(len) };
+            let mut packet = self.arena.split_to(len);
+            if packet.len() <= self.header_len {
+                return None;
+            }
+            packet.advance(self.header_len);
+            Some(packet.freeze())
         }
     }
 
@@ -539,24 +606,6 @@ mod platform {
         }
 
         Ok(())
-    }
-
-    fn read_buffer_len(packet_format: TunFdPacketFormat) -> usize {
-        match packet_format {
-            TunFdPacketFormat::RawIp => MAX_IP_PACKET_SIZE,
-            TunFdPacketFormat::DarwinUtun => MAX_IP_PACKET_SIZE + DARWIN_UTUN_HEADER_LEN,
-        }
-    }
-
-    fn decode_packet(packet_format: TunFdPacketFormat, packet: &[u8]) -> Option<Bytes> {
-        match packet_format {
-            TunFdPacketFormat::RawIp if !packet.is_empty() => Some(Bytes::copy_from_slice(packet)),
-            TunFdPacketFormat::RawIp => None,
-            TunFdPacketFormat::DarwinUtun if packet.len() > DARWIN_UTUN_HEADER_LEN => {
-                Some(Bytes::copy_from_slice(&packet[DARWIN_UTUN_HEADER_LEN..]))
-            }
-            TunFdPacketFormat::DarwinUtun => None,
-        }
     }
 
     enum EncodedPacket<'a> {
@@ -701,6 +750,106 @@ mod platform {
                     }
                 }
             }
+        }
+
+        /// Fills `reader`'s arena with `payload` the way a successful `read`
+        /// would, then carves the packet out of it.
+        fn feed(reader: &mut PacketReader, payload: &[u8]) -> Option<Bytes> {
+            if reader.arena.capacity() < reader.single_read {
+                reader.arena = BytesMut::with_capacity(reader.arena_len);
+            }
+            let spare = reader.arena.spare_capacity_mut();
+            assert!(spare.len() >= payload.len());
+            // SAFETY: `spare` has room for `payload`, which is initialized.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    payload.as_ptr(),
+                    spare.as_mut_ptr().cast::<u8>(),
+                    payload.len(),
+                );
+            }
+            reader.split_packet(payload.len())
+        }
+
+        #[test]
+        fn consecutive_packets_are_carved_out_of_one_arena() {
+            let mut reader = PacketReader::new(TunFdPacketFormat::RawIp, 1500);
+            let first = feed(&mut reader, &[1_u8; 1200]).expect("first packet");
+            let second = feed(&mut reader, &[2_u8; 300]).expect("second packet");
+
+            assert_eq!(first.len(), 1200);
+            assert_eq!(second.len(), 300);
+            assert!(first.iter().all(|byte| *byte == 1));
+            assert!(second.iter().all(|byte| *byte == 2));
+            // Both packets point into the same allocation, back to back: the
+            // second read neither allocated nor copied.
+            assert_eq!(unsafe { first.as_ptr().add(first.len()) }, second.as_ptr());
+        }
+
+        #[test]
+        fn a_new_arena_is_allocated_only_once_the_old_one_is_exhausted() {
+            const PAYLOAD: usize = 1500;
+            let mut reader = PacketReader::new(TunFdPacketFormat::RawIp, 1500);
+            let capacity = reader.arena.capacity();
+            let expected = (capacity - reader.single_read) / PAYLOAD + 1;
+            assert!(expected > 1, "the arena must amortize allocations");
+
+            let mut previous = feed(&mut reader, &[7_u8; PAYLOAD]).expect("packet");
+            let mut carved = 1;
+            loop {
+                let next = feed(&mut reader, &[7_u8; PAYLOAD]).expect("packet");
+                if unsafe { previous.as_ptr().add(previous.len()) } != next.as_ptr() {
+                    break;
+                }
+                previous = next;
+                carved += 1;
+            }
+
+            assert_eq!(
+                carved, expected,
+                "one arena must serve every read that still fits in it"
+            );
+        }
+
+        #[test]
+        fn the_darwin_utun_header_is_stripped_without_copying_the_payload() {
+            let mut reader = PacketReader::new(TunFdPacketFormat::DarwinUtun, 1500);
+            let mut framed = vec![0, 0, 0, libc::AF_INET as u8];
+            framed.extend_from_slice(&[0x45, 0x11, 0x22, 0x33]);
+
+            let packet = feed(&mut reader, &framed).expect("packet");
+
+            assert_eq!(&packet[..], &[0x45, 0x11, 0x22, 0x33]);
+        }
+
+        #[test]
+        fn a_read_that_carries_no_payload_yields_no_packet() {
+            let mut raw = PacketReader::new(TunFdPacketFormat::RawIp, 1500);
+            assert!(feed(&mut raw, &[]).is_none());
+
+            let mut utun = PacketReader::new(TunFdPacketFormat::DarwinUtun, 1500);
+            assert!(feed(&mut utun, &[0, 0, 0, libc::AF_INET as u8]).is_none());
+        }
+
+        #[test]
+        fn one_read_offers_room_for_an_oversized_packet_so_it_stays_rejectable() {
+            // Reading one byte past the MTU is what keeps an oversized packet
+            // observable: it comes back over the MTU and is dropped by
+            // `push_inbound`, instead of being silently truncated to a
+            // plausible-looking packet.
+            let raw = PacketReader::new(TunFdPacketFormat::RawIp, 1500);
+            assert_eq!(raw.single_read, 1501);
+
+            let utun = PacketReader::new(TunFdPacketFormat::DarwinUtun, 1500);
+            assert_eq!(utun.single_read, 1505);
+        }
+
+        #[test]
+        fn a_jumbo_mtu_arena_still_holds_one_whole_read() {
+            let reader = PacketReader::new(TunFdPacketFormat::DarwinUtun, MAX_IP_PACKET_SIZE);
+            assert_eq!(reader.single_read, MAX_IP_PACKET_SIZE + 5);
+            assert!(reader.arena_len >= reader.single_read);
+            assert!(reader.arena.capacity() >= reader.single_read);
         }
 
         fn test_packet_batch() -> Vec<Bytes> {

--- a/crates/xray-core-rs/tests/tun_fd_read_throughput.rs
+++ b/crates/xray-core-rs/tests/tun_fd_read_throughput.rs
@@ -1,0 +1,212 @@
+//! Read-path throughput harness for the direct-fd TUN bridge.
+//!
+//! Ignored by default: it is a measurement, not an assertion. Run with
+//!
+//! ```text
+//! cargo test --release -p xray-core-rs --test tun_fd_read_throughput -- --ignored --nocapture
+//! ```
+//!
+//! A `socketpair(AF_UNIX, SOCK_DGRAM)` stands in for the platform descriptor:
+//! it has the same datagram read semantics as a Darwin utun fd (one packet per
+//! `read`, a short read discards the rest), so the loop under test is exercised
+//! unchanged and no elevated privileges are needed.
+
+#![cfg(unix)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::os::fd::RawFd;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use xray_core_rs::{TunFdClosePolicy, TunFdConfig, TunFdPacketFormat, TunFdRuntime};
+use xray_tun::{TunConfig, TunEndpoint};
+
+/// Counts allocations so the harness can report allocator traffic, which is
+/// what the read path actually changes — throughput here is dominated by the
+/// descriptor syscall.
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+
+// SAFETY: every method forwards to `System` unchanged.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Overridable so one harness covers both a realistic MTU and a payload large
+/// enough to make the per-packet copy dominate: `TUN_BENCH_MTU`,
+/// `TUN_BENCH_PACKET_LEN`, `TUN_BENCH_PACKETS`.
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn socketpair(buffer_bytes: usize) -> (RawFd, RawFd) {
+    let mut fds = [0 as libc::c_int; 2];
+    // SAFETY: `fds` is a two-element array the call fills in.
+    let rc = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr()) };
+    assert_eq!(
+        rc,
+        0,
+        "socketpair failed: {}",
+        std::io::Error::last_os_error()
+    );
+    // The default datagram buffer is far below a jumbo payload, so a single
+    // write would fail with EMSGSIZE before the read path is exercised.
+    for fd in fds {
+        for option in [libc::SO_SNDBUF, libc::SO_RCVBUF] {
+            let size = buffer_bytes as libc::c_int;
+            // SAFETY: `size` is a live `c_int` of the length passed in.
+            unsafe {
+                libc::setsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    option,
+                    std::ptr::addr_of!(size).cast(),
+                    std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                );
+            }
+        }
+    }
+    (fds[0], fds[1])
+}
+
+/// Peak resident set size of this process, in bytes.
+fn peak_rss_bytes() -> u64 {
+    // SAFETY: `usage` is a live, correctly sized `rusage`.
+    let mut usage = unsafe { std::mem::zeroed::<libc::rusage>() };
+    // SAFETY: the call only writes into `usage`.
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } != 0 {
+        return 0;
+    }
+    let max_rss = usage.ru_maxrss as u64;
+    // Darwin reports bytes, Linux kilobytes.
+    if cfg!(target_os = "macos") {
+        max_rss
+    } else {
+        max_rss * 1024
+    }
+}
+
+fn ipv4_packet(len: usize, seed: u8) -> Vec<u8> {
+    let mut packet = vec![seed; len];
+    packet[0] = 0x45;
+    packet
+}
+
+#[test]
+#[ignore = "throughput measurement, run explicitly"]
+fn direct_fd_read_path_throughput() {
+    let mtu = env_usize("TUN_BENCH_MTU", 1500);
+    let packet_len = env_usize("TUN_BENCH_PACKET_LEN", 1400);
+    let packets = env_usize("TUN_BENCH_PACKETS", 200_000);
+    let queue_depth = env_usize("TUN_BENCH_QUEUE_DEPTH", 1024);
+    assert!(packet_len <= mtu, "payload must fit the mtu");
+
+    let (host_fd, tun_fd) = socketpair((packet_len * 64).max(256 * 1024));
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    let tun = Arc::new(TunEndpoint::new_with_queue_depths(
+        TunConfig { mtu, queue_depth },
+        queue_depth,
+        queue_depth,
+    ));
+
+    let bridge = runtime
+        .block_on(async {
+            TunFdRuntime::start(
+                TunFdConfig::new(tun_fd, TunFdPacketFormat::RawIp, TunFdClosePolicy::Owned),
+                Arc::clone(&tun),
+            )
+        })
+        .expect("fd bridge");
+
+    let packet = ipv4_packet(packet_len, 0xAB);
+    let producer = std::thread::spawn(move || {
+        let mut sent = 0_usize;
+        while sent < packets {
+            // SAFETY: `packet` outlives the call and `host_fd` is open.
+            let written = unsafe { libc::write(host_fd, packet.as_ptr().cast(), packet.len()) };
+            if written < 0 {
+                let err = std::io::Error::last_os_error();
+                match err.raw_os_error() {
+                    // A datagram socketpair reports a full buffer instead of
+                    // blocking, so the producer paces itself against the
+                    // reader rather than dropping the packet.
+                    Some(libc::EINTR | libc::ENOBUFS | libc::EAGAIN) => {
+                        std::thread::yield_now();
+                        continue;
+                    }
+                    _ => panic!("write failed: {err}"),
+                }
+            }
+            sent += 1;
+        }
+        // SAFETY: the producer owns `host_fd` and is done with it.
+        unsafe { libc::close(host_fd) };
+    });
+
+    let allocations_before = ALLOCATIONS.load(Ordering::Relaxed);
+    let started = Instant::now();
+    let received = runtime.block_on(async {
+        let mut received = 0_usize;
+        while received < packets {
+            match tokio::time::timeout(Duration::from_secs(5), tun.poll_inbound()).await {
+                Ok(Ok(packet)) => {
+                    assert_eq!(packet.len(), packet_len);
+                    received += 1;
+                }
+                Ok(Err(err)) => panic!("queue closed after {received} packets: {err}"),
+                Err(_) => break,
+            }
+        }
+        received
+    });
+    let elapsed = started.elapsed();
+
+    producer.join().expect("producer");
+    runtime.block_on(bridge.stop());
+
+    let stats = runtime.block_on(tun.stats());
+    let per_packet = elapsed.as_secs_f64() / received.max(1) as f64;
+    println!(
+        "mtu {mtu} payload {packet_len}: received {received}/{packets} ({} dropped) in {:.3} s — {:.1} ns/packet, {:.2} Mpps, {:.1} MB/s",
+        stats.dropped_packets,
+        elapsed.as_secs_f64(),
+        per_packet * 1e9,
+        1.0 / per_packet / 1e6,
+        (received * packet_len) as f64 / elapsed.as_secs_f64() / 1e6,
+    );
+    let allocations = ALLOCATIONS.load(Ordering::Relaxed) - allocations_before;
+    println!(
+        "{allocations} allocations — {:.2} per packet",
+        allocations as f64 / received.max(1) as f64
+    );
+    println!(
+        "peak rss {:.1} MiB",
+        peak_rss_bytes() as f64 / (1024.0 * 1024.0)
+    );
+}


### PR DESCRIPTION
## Summary

The direct-fd TUN bridge — the path macOS and Android hosts use when they hand the core a descriptor instead of running a packet pump — read each packet into a reusable `Vec<u8>` and then handed `decode_packet` a slice, which allocated a fresh `Bytes` and copied the whole packet into it. Every packet arriving from the descriptor cost exactly one allocation plus a memcpy of up to the MTU before it reached the inbound queue.

- **`PacketReader`** owns a `BytesMut` arena. The `read` lands directly in the arena's spare capacity and `split_to` carves the packet off the front, so consecutive packets share one allocation and are released by refcount once the stack has consumed the last of them. A Darwin utun header is dropped by advancing the split rather than by copying past it, so the `DarwinUtun` format costs nothing over `RawIp`.
- **Not a ring buffer.** Packets leave the queue in whatever order the stack consumes them, so a ring's tail would stall behind the longest-lived packet; copying a packet out of the ring to avoid that stall is precisely the copy being removed. Refcounted chunks drop the ordering requirement — a chunk lives exactly as long as its longest-lived packet.
- **Arena size is 64 KiB**, or one whole read when the MTU needs more. That holds ~46 MTU-sized packets per allocation, and is no larger than the single maximum-size packet buffer the old path could already allocate, which bounds what one long-lived packet can pin. Throughput keeps improving from 4 KiB up to 256 KiB (medians 1063 / 1045 / 962 / 926 ns per packet); 64 KiB takes most of that while keeping the bound.
- **The exhausted arena is released, not recycled.** `try_reclaim` was implemented and measured first: it never succeeds, because the packet just carved out of the arena is still in flight at the moment the arena runs out. Allocation counts were identical with and without it at every queue depth from 1 to 1024, so it was removed rather than left in as dead intent.
- **One read is offered `mtu + header + 1` bytes.** The extra byte is what keeps an oversized packet observable: it comes back one byte over the MTU and `push_inbound` rejects it exactly as it did when the whole oversized packet was read and rejected, instead of being silently truncated into a plausible-looking packet.

`read_buffer_len` and `decode_packet` are gone; `grep -rn "decode_packet\|read_buffer_len" crates` is empty. The write path is untouched — it already batches under one `writable()` guard and uses `writev` for the utun header.

## Behaviour

No intended change. An oversized packet is still dropped with the same counter, a read carrying no payload still yields no packet, and both packet formats decode to the same bytes. The one difference is memory shape: a packet now points into a shared 64 KiB chunk instead of owning a private allocation, so a packet held by the stack pins its chunk until it is dropped.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --exclude xray-rust-fuzz --all-targets --all-features -- -D warnings -W clippy::perf -W clippy::suspicious` — clean (fuzz crate excluded only because `libfuzzer-sys` can't build its C++ on the dev machine; CI runs the full set)
- `cargo test -p xray-core-rs -p xray-tun -p xray-ffi` — 731 passed, 0 failed, 27 ignored

Six new unit tests cover the carve: consecutive packets are physically adjacent in one allocation, a new arena is taken only once the old one cannot hold another read, the utun header is stripped without copying, a read with no payload yields nothing, one read leaves room for an oversized packet, and a jumbo MTU still gets an arena that holds one whole read.

## Benchmark

**Hardware/OS:** Apple M2 Pro (12 cores), 32 GB RAM, macOS 26.6.2; `cargo build --release`; single process, no other load. `main` and branch run interleaved, five runs each, via the new harness:

```
cargo test --release -p xray-core-rs --test tun_fd_read_throughput -- --ignored --nocapture
```

It drives `TunFdRuntime` against a `socketpair(AF_UNIX, SOCK_DGRAM)`, which has the same datagram read semantics as a Darwin utun descriptor (one packet per `read`, a short read discards the rest), so no elevated privileges are needed. MTU 1500, 1400-byte payloads, 500 000 packets.

| Metric | `main` | branch |
|---|---|---|
| allocations per packet | 1.00 (500 015–500 019) | **0.04 (21 754–21 762)** |
| ns/packet, median (range) | 999 (956–1064) | 949 (907–1057) |
| peak RSS | 2.5–2.6 MiB | 2.7–2.8 MiB |

Allocator traffic is the deterministic result: a 23x drop, varying by ±10 allocations across runs. Wall-clock throughput improves ~5% at the median but the ranges overlap — this harness is dominated by the descriptor syscall, so the copy is a small share of it. Peak RSS rises ~0.2 MiB, which is the arena.

Peak RSS stays flat as the load grows — 2.8 MiB at 500 000 packets, 2.8 MiB at 2 000 000, 2.9 MiB at 5 000 000 — with allocations tracking at 0.04 per packet throughout, so exhausted arenas are being freed rather than accumulated. Leaking them would have cost roughly 7 GB at the largest count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)