### PR TITLE
ci: register v0.6 release evidence validation

### DIFF
--- a/.github/workflows/v06-release-evidence.yml
+++ b/.github/workflows/v06-release-evidence.yml
@@ -1,0 +1,54 @@
+name: v0.6 release evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_url:
+        description: HTTPS URL of the bounded physical-device and performance evidence ZIP
+        required: true
+        type: string
+      evidence_sha256:
+        description: Lowercase SHA-256 of the evidence ZIP
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v06-release-evidence-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact evidence candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download and validate exact-candidate evidence
+        env:
+          EVIDENCE_URL: ${{ inputs.evidence_url }}
+          EVIDENCE_SHA256: ${{ inputs.evidence_sha256 }}
+        run: |
+          [[ "$EVIDENCE_URL" == https://* ]]
+          [[ "$EVIDENCE_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          archive="$RUNNER_TEMP/v06-release-evidence.zip"
+          curl --fail --location --silent --show-error \
+            --proto '=https' --tlsv1.2 --retry 3 \
+            --max-filesize 268435456 \
+            --output "$archive" "$EVIDENCE_URL"
+          echo "$EVIDENCE_SHA256  $archive" | sha256sum --check -
+          tree="$(git rev-parse 'HEAD^{tree}')"
+          python3 scripts/check-v06-release-evidence.py "$archive" "$GITHUB_SHA" "$tree"
+
+      - name: Preserve validated release evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v06-release-evidence-${{ github.sha }}
+          path: ${{ runner.temp }}/v06-release-evidence.zip
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/check-v06-release-evidence.py
+++ b/scripts/check-v06-release-evidence.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Validate exact-candidate v0.6 physical-device and performance evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import pathlib
+import re
+import stat
+import statistics
+import sys
+import zipfile
+from typing import Any
+
+
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+MAX_ARCHIVE_BYTES = 256 * 1024 * 1024
+MAX_MANIFEST_BYTES = 1024 * 1024
+REQUIRED_PLATFORMS = {"apple", "android"}
+REQUIRED_SCENARIOS = {
+    "vless-encryption",
+    "ip-on-demand",
+    "xhttp-download-session",
+    "cancellation",
+    "host-adapter-projection",
+}
+REQUIRED_DEVICE_ARTIFACTS = {
+    "resource-profile",
+    "sanitized-log",
+    "transition-timeline",
+}
+MEASUREMENT_COMPARISONS = {
+    "process-throughput": "at-least",
+    "vless-encryption-throughput": "at-least",
+    "ip-on-demand-latency": "at-most",
+    "xhttp-memory": "at-most",
+}
+REQUIRED_PERFORMANCE_ARTIFACTS = {"benchmark-raw", "build-manifest"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON field: {key}")
+        result[key] = value
+    return result
+
+
+def require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{label} must be an object")
+    return value
+
+
+def require_fields(value: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        fail(
+            f"{label} fields differ: missing={sorted(expected - set(value))!r} "
+            f"unexpected={sorted(set(value) - expected)!r}"
+        )
+
+
+def require_string(value: Any, label: str, maximum: int = 512) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        fail(f"{label} must be a nonempty string of at most {maximum} characters")
+    if any(ord(character) < 0x20 for character in value):
+        fail(f"{label} contains a control character")
+    return value
+
+
+def require_int(value: Any, label: str, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        fail(f"{label} must be an integer >= {minimum}")
+    return value
+
+
+def require_number(value: Any, label: str, *, positive: bool = False) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        fail(f"{label} must be a finite number")
+    result = float(value)
+    if not math.isfinite(result) or result < 0 or (positive and result <= 0):
+        fail(f"{label} is outside its allowed numeric range")
+    return result
+
+
+def require_pass(value: Any, label: str) -> None:
+    if value != "pass":
+        fail(f"{label} must be 'pass'")
+
+
+def validate_relative_path(value: Any, label: str) -> str:
+    raw = require_string(value, label)
+    path = pathlib.PurePosixPath(raw)
+    if "\\" in raw or path.is_absolute() or raw.endswith("/") or any(
+        part in {"", ".", ".."} for part in raw.split("/")
+    ):
+        fail(f"{label} must be a normalized relative file path")
+    return raw
+
+
+def validate_artifacts(
+    raw: Any,
+    required_kinds: set[str],
+    label: str,
+    expected_files: dict[str, str],
+) -> None:
+    if not isinstance(raw, list):
+        fail(f"{label} must be an array")
+    kinds: list[str] = []
+    for index, raw_artifact in enumerate(raw):
+        artifact_label = f"{label}[{index}]"
+        artifact = require_object(raw_artifact, artifact_label)
+        require_fields(artifact, {"kind", "path", "sha256"}, artifact_label)
+        kind = require_string(artifact["kind"], f"{artifact_label}.kind", 64)
+        path = validate_relative_path(artifact["path"], f"{artifact_label}.path")
+        digest = require_string(artifact["sha256"], f"{artifact_label}.sha256", 64)
+        if not SHA256.fullmatch(digest):
+            fail(f"{artifact_label}.sha256 must be lowercase SHA-256")
+        if path in expected_files:
+            fail(f"artifact path is repeated: {path}")
+        kinds.append(kind)
+        expected_files[path] = digest
+    if len(kinds) != len(set(kinds)) or set(kinds) != required_kinds:
+        fail(f"{label} kinds must be exactly {sorted(required_kinds)!r}")
+
+
+def validate_device(
+    raw: Any,
+    label: str,
+    expected_files: dict[str, str],
+) -> str:
+    device = require_object(raw, label)
+    require_fields(
+        device,
+        {
+            "platform",
+            "physical",
+            "model",
+            "osVersion",
+            "architecture",
+            "durationSeconds",
+            "scenarios",
+            "limits",
+            "observed",
+            "artifacts",
+            "result",
+        },
+        label,
+    )
+    platform = require_string(device["platform"], f"{label}.platform", 16)
+    if platform not in REQUIRED_PLATFORMS:
+        fail(f"{label}.platform is unsupported")
+    if device["physical"] is not True:
+        fail(f"{label}.physical must be true")
+    for field in ("model", "osVersion", "architecture"):
+        require_string(device[field], f"{label}.{field}", 128)
+    require_int(device["durationSeconds"], f"{label}.durationSeconds", 1)
+    require_pass(device["result"], f"{label}.result")
+
+    scenarios = device["scenarios"]
+    if not isinstance(scenarios, list):
+        fail(f"{label}.scenarios must be an array")
+    scenario_ids: list[str] = []
+    for index, raw_scenario in enumerate(scenarios):
+        scenario_label = f"{label}.scenarios[{index}]"
+        scenario = require_object(raw_scenario, scenario_label)
+        require_fields(
+            scenario,
+            {"id", "durationSeconds", "transitions", "trafficResult", "result"},
+            scenario_label,
+        )
+        scenario_ids.append(require_string(scenario["id"], f"{scenario_label}.id", 64))
+        require_int(scenario["durationSeconds"], f"{scenario_label}.durationSeconds", 1)
+        transitions = scenario["transitions"]
+        if not isinstance(transitions, list) or not transitions:
+            fail(f"{scenario_label}.transitions must be a nonempty array")
+        for transition_index, transition in enumerate(transitions):
+            require_string(
+                transition,
+                f"{scenario_label}.transitions[{transition_index}]",
+                128,
+            )
+        require_pass(scenario["trafficResult"], f"{scenario_label}.trafficResult")
+        require_pass(scenario["result"], f"{scenario_label}.result")
+    if len(scenario_ids) != len(set(scenario_ids)) or set(scenario_ids) != REQUIRED_SCENARIOS:
+        fail(f"{label}.scenarios must be exactly {sorted(REQUIRED_SCENARIOS)!r}")
+
+    limit_fields = {
+        "residentMemoryGrowthBytes",
+        "threadGrowth",
+        "fatalErrors",
+        "unrecoveredTransitions",
+    }
+    limits = require_object(device["limits"], f"{label}.limits")
+    observed = require_object(device["observed"], f"{label}.observed")
+    require_fields(limits, limit_fields, f"{label}.limits")
+    require_fields(observed, limit_fields, f"{label}.observed")
+    for field in limit_fields:
+        minimum = 1 if field == "residentMemoryGrowthBytes" else 0
+        maximum = require_int(limits[field], f"{label}.limits.{field}", minimum)
+        actual = require_int(observed[field], f"{label}.observed.{field}")
+        if actual > maximum:
+            fail(f"{label}.observed.{field} exceeds its explicit limit")
+    if limits["fatalErrors"] != 0 or limits["unrecoveredTransitions"] != 0:
+        fail(f"{label} must set zero tolerance for fatal or unrecovered errors")
+
+    validate_artifacts(
+        device["artifacts"],
+        REQUIRED_DEVICE_ARTIFACTS,
+        f"{label}.artifacts",
+        expected_files,
+    )
+    return platform
+
+
+def validate_manifest(
+    data: bytes,
+    expected_revision: str,
+    expected_tree: str,
+) -> dict[str, str]:
+    if len(data) > MAX_MANIFEST_BYTES:
+        fail("manifest.json exceeds 1 MiB")
+    try:
+        manifest = json.loads(data, object_pairs_hook=reject_duplicate_keys)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"invalid manifest.json: {error}")
+    manifest = require_object(manifest, "manifest")
+    require_fields(
+        manifest,
+        {"schemaVersion", "candidate", "devices", "performance", "result"},
+        "manifest",
+    )
+    if manifest["schemaVersion"] != 1:
+        fail("manifest.schemaVersion must be 1")
+    require_pass(manifest["result"], "manifest.result")
+
+    candidate = require_object(manifest["candidate"], "manifest.candidate")
+    require_fields(candidate, {"revision", "tree", "dirty"}, "manifest.candidate")
+    if candidate["revision"] != expected_revision or not SHA40.fullmatch(expected_revision):
+        fail("candidate revision does not match the release commit")
+    if candidate["tree"] != expected_tree or not SHA40.fullmatch(expected_tree):
+        fail("candidate tree does not match the release tree")
+    if candidate["dirty"] is not False:
+        fail("candidate.dirty must be false")
+
+    expected_files: dict[str, str] = {}
+    devices = manifest["devices"]
+    if not isinstance(devices, list):
+        fail("manifest.devices must be an array")
+    platforms = [
+        validate_device(device, f"manifest.devices[{index}]", expected_files)
+        for index, device in enumerate(devices)
+    ]
+    if len(platforms) != 2 or set(platforms) != REQUIRED_PLATFORMS:
+        fail("manifest.devices must contain one physical Apple and one physical Android report")
+
+    performance = require_object(manifest["performance"], "manifest.performance")
+    require_fields(
+        performance,
+        {"profile", "clean", "measurements", "artifacts", "result"},
+        "manifest.performance",
+    )
+    if performance["profile"] != "release" or performance["clean"] is not True:
+        fail("performance evidence must be a clean release-profile build")
+    require_pass(performance["result"], "manifest.performance.result")
+    measurements = performance["measurements"]
+    if not isinstance(measurements, list):
+        fail("manifest.performance.measurements must be an array")
+    measurement_ids: list[str] = []
+    for index, raw_measurement in enumerate(measurements):
+        label = f"manifest.performance.measurements[{index}]"
+        measurement = require_object(raw_measurement, label)
+        require_fields(
+            measurement,
+            {"id", "unit", "samples", "comparison", "threshold"},
+            label,
+        )
+        measurement_id = require_string(measurement["id"], f"{label}.id", 64)
+        measurement_ids.append(measurement_id)
+        require_string(measurement["unit"], f"{label}.unit", 32)
+        comparison = require_string(
+            measurement["comparison"], f"{label}.comparison", 16
+        )
+        expected_comparison = MEASUREMENT_COMPARISONS.get(measurement_id)
+        if comparison != expected_comparison:
+            fail(
+                f"{label}.comparison must be {expected_comparison!r} "
+                f"for {measurement_id!r}"
+            )
+        threshold = require_number(
+            measurement["threshold"], f"{label}.threshold", positive=True
+        )
+        samples = measurement["samples"]
+        if not isinstance(samples, list) or len(samples) < 5:
+            fail(f"{label}.samples must contain at least five clean runs")
+        checked = [
+            require_number(sample, f"{label}.samples[{sample_index}]", positive=True)
+            for sample_index, sample in enumerate(samples)
+        ]
+        median = statistics.median(checked)
+        if comparison == "at-most" and median > threshold:
+            fail(f"{label} median exceeds its explicit maximum")
+        if comparison == "at-least" and median < threshold:
+            fail(f"{label} median is below its explicit minimum")
+    required_measurements = set(MEASUREMENT_COMPARISONS)
+    if (
+        len(measurement_ids) != len(set(measurement_ids))
+        or set(measurement_ids) != required_measurements
+    ):
+        fail(
+            f"performance measurements must be exactly "
+            f"{sorted(required_measurements)!r}"
+        )
+    validate_artifacts(
+        performance["artifacts"],
+        REQUIRED_PERFORMANCE_ARTIFACTS,
+        "manifest.performance.artifacts",
+        expected_files,
+    )
+    return expected_files
+
+
+def validate_archive(path: pathlib.Path, revision: str, tree: str) -> None:
+    if path.stat().st_size > MAX_ARCHIVE_BYTES:
+        fail("evidence ZIP exceeds 256 MiB")
+    with zipfile.ZipFile(path) as archive:
+        infos = archive.infolist()
+        names = [info.filename for info in infos]
+        if len(names) != len(set(names)):
+            fail("evidence ZIP contains duplicate entries")
+        total_size = 0
+        for info in infos:
+            raw = info.filename
+            validate_relative_path(raw.removesuffix("/"), f"ZIP entry {raw!r}")
+            mode = info.external_attr >> 16
+            if mode and stat.S_ISLNK(mode):
+                fail(f"evidence ZIP contains a symbolic link: {raw}")
+            if info.flag_bits & 0x1:
+                fail(f"evidence ZIP contains an encrypted entry: {raw}")
+            total_size += info.file_size
+            if total_size > MAX_ARCHIVE_BYTES:
+                fail("evidence ZIP expands beyond 256 MiB")
+            if info.file_size > 1024 * 1024 and info.compress_size * 200 < info.file_size:
+                fail(f"evidence ZIP entry has an unsafe compression ratio: {raw}")
+
+        try:
+            manifest_data = archive.read("manifest.json")
+        except KeyError:
+            fail("evidence ZIP is missing manifest.json")
+        expected_files = validate_manifest(manifest_data, revision, tree)
+        files = {name for name in names if not name.endswith("/")}
+        expected_names = {"manifest.json", *expected_files}
+        if files != expected_names:
+            fail(
+                f"evidence ZIP file set differs: missing={sorted(expected_names - files)!r} "
+                f"unexpected={sorted(files - expected_names)!r}"
+            )
+        expected_dirs = {
+            f"{parent}/"
+            for name in expected_names
+            for parent in list(pathlib.PurePosixPath(name).parents)[:-1]
+        }
+        directories = {name for name in names if name.endswith("/")}
+        if not directories <= expected_dirs:
+            fail(f"evidence ZIP has unexpected directories: {sorted(directories - expected_dirs)!r}")
+        for artifact_path, expected_digest in expected_files.items():
+            actual = hashlib.sha256(archive.read(artifact_path)).hexdigest()
+            if actual != expected_digest:
+                fail(f"artifact checksum differs: {artifact_path}")
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            f"usage: {sys.argv[0]} <evidence.zip> <expected-revision> <expected-tree>",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        validate_archive(pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3])
+    except (OSError, ValidationError, zipfile.BadZipFile) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(f"v0.6 release evidence passed for {sys.argv[2]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_v06_release_evidence.py
+++ b/scripts/tests/test_v06_release_evidence.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "check_v06_release_evidence", ROOT / "scripts/check-v06-release-evidence.py"
+)
+assert SPEC and SPEC.loader
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+REVISION = "1" * 40
+TREE = "2" * 40
+
+
+class V06ReleaseEvidenceTests(unittest.TestCase):
+    def evidence(self):
+        blobs = {}
+
+        def artifacts(prefix, kinds):
+            result = []
+            for kind in kinds:
+                path = f"{prefix}/{kind}.txt"
+                data = f"{prefix}:{kind}".encode()
+                blobs[path] = data
+                result.append(
+                    {"kind": kind, "path": path, "sha256": hashlib.sha256(data).hexdigest()}
+                )
+            return result
+
+        scenarios = [
+            {
+                "id": scenario,
+                "durationSeconds": 1,
+                "transitions": ["start-stop"],
+                "trafficResult": "pass",
+                "result": "pass",
+            }
+            for scenario in sorted(VALIDATOR.REQUIRED_SCENARIOS)
+        ]
+        devices = []
+        for platform in sorted(VALIDATOR.REQUIRED_PLATFORMS):
+            devices.append(
+                {
+                    "platform": platform,
+                    "physical": True,
+                    "model": f"{platform}-device",
+                    "osVersion": "1.0",
+                    "architecture": "arm64",
+                    "durationSeconds": 10,
+                    "scenarios": scenarios,
+                    "limits": {
+                        "residentMemoryGrowthBytes": 1024,
+                        "threadGrowth": 2,
+                        "fatalErrors": 0,
+                        "unrecoveredTransitions": 0,
+                    },
+                    "observed": {
+                        "residentMemoryGrowthBytes": 0,
+                        "threadGrowth": 0,
+                        "fatalErrors": 0,
+                        "unrecoveredTransitions": 0,
+                    },
+                    "artifacts": artifacts(
+                        platform, sorted(VALIDATOR.REQUIRED_DEVICE_ARTIFACTS)
+                    ),
+                    "result": "pass",
+                }
+            )
+        measurements = [
+            {
+                "id": item,
+                "unit": "units",
+                "samples": [2, 2, 2, 2, 2],
+                "comparison": comparison,
+                "threshold": 1 if comparison == "at-least" else 3,
+            }
+            for item, comparison in sorted(VALIDATOR.MEASUREMENT_COMPARISONS.items())
+        ]
+        manifest = {
+            "schemaVersion": 1,
+            "candidate": {"revision": REVISION, "tree": TREE, "dirty": False},
+            "devices": devices,
+            "performance": {
+                "profile": "release",
+                "clean": True,
+                "measurements": measurements,
+                "artifacts": artifacts(
+                    "performance", sorted(VALIDATOR.REQUIRED_PERFORMANCE_ARTIFACTS)
+                ),
+                "result": "pass",
+            },
+            "result": "pass",
+        }
+        return manifest, blobs
+
+    def write_zip(self, mutate=None):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        path = Path(temporary.name) / "evidence.zip"
+        manifest, blobs = self.evidence()
+        if mutate:
+            mutate(manifest, blobs)
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("manifest.json", json.dumps(manifest))
+            for name, data in blobs.items():
+                archive.writestr(name, data)
+        return path
+
+    def test_valid_exact_candidate_evidence(self):
+        VALIDATOR.validate_archive(self.write_zip(), REVISION, TREE)
+
+    def test_wrong_candidate_is_rejected(self):
+        path = self.write_zip(
+            lambda manifest, _: manifest["candidate"].__setitem__("revision", "3" * 40)
+        )
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "candidate revision"):
+            VALIDATOR.validate_archive(path, REVISION, TREE)
+
+    def test_missing_device_scenario_is_rejected(self):
+        path = self.write_zip(lambda manifest, _: manifest["devices"][0]["scenarios"].pop())
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "scenarios must be exactly"):
+            VALIDATOR.validate_archive(path, REVISION, TREE)
+
+    def test_performance_regression_is_rejected(self):
+        def regress_latency(manifest, _):
+            measurement = next(
+                item
+                for item in manifest["performance"]["measurements"]
+                if item["comparison"] == "at-most"
+            )
+            measurement.update({"samples": [4, 4, 4, 4, 4], "threshold": 3})
+
+        path = self.write_zip(
+            regress_latency
+        )
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "median exceeds"):
+            VALIDATOR.validate_archive(path, REVISION, TREE)
+
+    def test_throughput_regression_is_rejected(self):
+        def regress_throughput(manifest, _):
+            measurement = next(
+                item
+                for item in manifest["performance"]["measurements"]
+                if item["comparison"] == "at-least"
+            )
+            measurement.update({"samples": [1, 1, 1, 1, 1], "threshold": 2})
+
+        path = self.write_zip(regress_throughput)
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "below its explicit minimum"):
+            VALIDATOR.validate_archive(path, REVISION, TREE)
+
+    def test_measurement_cannot_reverse_its_required_comparison(self):
+        def reverse_comparison(manifest, _):
+            measurement = next(
+                item
+                for item in manifest["performance"]["measurements"]
+                if item["comparison"] == "at-least"
+            )
+            measurement["comparison"] = "at-most"
+
+        path = self.write_zip(reverse_comparison)
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "comparison must be"):
+            VALIDATOR.validate_archive(path, REVISION, TREE)
+
+    def test_unlisted_file_is_rejected(self):
+        path = self.write_zip(lambda _, blobs: blobs.__setitem__("extra.txt", b"extra"))
+        with self.assertRaisesRegex(VALIDATOR.ValidationError, "file set differs"):
+            VALIDATOR.validate_archive(path, REVISION, TREE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Register the existing v0.6 release-evidence workflow on the default branch so GitHub can dispatch it for the frozen release candidate. Copy the workflow, strict archive validator and its regression tests byte-for-byte from candidate 1e713ca3e6c57be5747b4915b31e0db040a01c0c.

## Verification

- `python3 -m unittest scripts.tests.test_v06_release_evidence`: 7 tests passed.
- All three files match the previously validated candidate.
- Candidate CI: https://github.com/aimalygin/xray-rust/actions/runs/33991923429

## Compatibility and security

No runtime, configuration, ABI or release-budget changes. The workflow has read-only repository permissions, checks the ZIP hash and exact candidate commit/tree, and retains only a validated archive.