### PR TITLE
Prepare stable v0.6.0 and preserve measured RC evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           else
             echo "is_rc=false" >>"$GITHUB_OUTPUT"
           fi
-          if [[ "$is_rc" == true || "$GITHUB_EVENT_NAME" == workflow_dispatch || "$GITHUB_REF" == refs/heads/codex/v06-candidate ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* || "$GITHUB_EVENT_NAME" == workflow_dispatch || "$GITHUB_REF" == refs/heads/codex/v06-candidate ]]; then
             echo "run_release_gates=true" >>"$GITHUB_OUTPUT"
           else
             echo "run_release_gates=false" >>"$GITHUB_OUTPUT"
@@ -120,7 +120,7 @@ jobs:
           retention-days: 14
 
   release-evidence:
-    if: needs.release-metadata.outputs.is_rc == 'true'
+    if: needs.release-metadata.outputs.is_rc == 'true' || github.ref == 'refs/tags/v0.6.0'
     needs: release-metadata
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -132,6 +132,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.release-metadata.outputs.candidate_commit }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Download validated exact-candidate evidence
@@ -158,7 +159,7 @@ jobs:
         run: |
           archive="$RUNNER_TEMP/v06-release-evidence/v06-release-evidence.zip"
           test -f "$archive"
-          python3 scripts/check-v06-release-evidence.py \
+          bash scripts/check-v06-release-evidence.sh \
             "$archive" "$CANDIDATE_COMMIT" "$CANDIDATE_TREE"
 
   secrets:
@@ -230,7 +231,7 @@ jobs:
           bash scripts/tests/check-v05-performance.test.sh
           bash scripts/tests/check-v05-host-hardening.test.sh
           bash scripts/tests/check-mobile-device-evidence.test.sh
-          python3 -m unittest scripts.tests.test_v06_release_evidence
+          python3 -m unittest scripts.tests.test_v06_release_evidence scripts.tests.test_v06_stable_promotion
           bash scripts/tests/bench-xhttp-memory.test.sh
           if [[ -f docs/benchmarks/results/2026-08-29-v26.7.28/manifest.json ]]; then
             python3 scripts/check-benchmark-publication.py docs/benchmarks/results/2026-08-29-v26.7.28

--- a/.github/workflows/v06-release-evidence.yml
+++ b/.github/workflows/v06-release-evidence.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       evidence_url:
-        description: HTTPS URL of the bounded physical-device and performance evidence ZIP
+        description: HTTPS URL of exact-candidate evidence, or the published RC ZIP for stable promotion
         required: true
         type: string
       evidence_sha256:
@@ -27,6 +27,7 @@ jobs:
       - name: Check out exact evidence candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Download and validate exact-candidate evidence
@@ -43,12 +44,15 @@ jobs:
             --output "$archive" "$EVIDENCE_URL"
           echo "$EVIDENCE_SHA256  $archive" | sha256sum --check -
           tree="$(git rev-parse 'HEAD^{tree}')"
-          python3 scripts/check-v06-release-evidence.py "$archive" "$GITHUB_SHA" "$tree"
+          bash scripts/check-v06-release-evidence.sh "$archive" "$GITHUB_SHA" "$tree" \
+            | tee "$RUNNER_TEMP/v06-evidence-validation.txt"
 
       - name: Preserve validated release evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: v06-release-evidence-${{ github.sha }}
-          path: ${{ runner.temp }}/v06-release-evidence.zip
+          path: |
+            ${{ runner.temp }}/v06-release-evidence.zip
+            ${{ runner.temp }}/v06-evidence-validation.txt
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/v06-release-evidence.yml
+++ b/.github/workflows/v06-release-evidence.yml
@@ -45,7 +45,8 @@ jobs:
           echo "$EVIDENCE_SHA256  $archive" | sha256sum --check -
           tree="$(git rev-parse 'HEAD^{tree}')"
           bash scripts/check-v06-release-evidence.sh "$archive" "$GITHUB_SHA" "$tree" \
-            | tee "$RUNNER_TEMP/v06-evidence-validation.txt"
+            > "$RUNNER_TEMP/v06-evidence-validation.txt"
+          cat "$RUNNER_TEMP/v06-evidence-validation.txt"
 
       - name: Preserve validated release evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ long-term supported release series.
 
 ## Unreleased
 
+## 0.6.0 - 2026-09-08
+
+- Promotes the completed v0.6 RC scope: bounded VLESS 1-RTT/0-RTT encryption,
+  lazy `IPOnDemand` routing, independent XHTTP downloads, mobile projection,
+  and supported-configuration schema and CLI tooling.
+- Preserves the RC runtime, dependencies, adapters and C ABI. Only version
+  metadata, release verification tooling and documentation change; a blocking
+  promotion check verifies that boundary against the published RC commit.
+- The owner confirmed RC profile import, connect, disconnect and reconnect in
+  a real application on 2026-09-08. This is an owner report, separate from CI
+  and the archived bounded iPhone 13 / Samsung device campaigns.
+- Accepts the published RC device and performance evidence with its original
+  commit/tree identity. Long device soak campaigns are removed from the
+  current release checklist at the owner's request and are not claimed.
+  Final automated builds and release gates run on the stable source revision.
+- See [stable promotion](docs/v06-stable-promotion.md) for provenance,
+  publication steps and the exact verification boundary.
+
 ## 0.6.0-rc.1 - 2026-09-05
 
 - Published the frozen source candidate and matching mobile SDK after the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes will be documented in this file.
 
 In this changelog, the stable channel means a non-prerelease tag eligible for
-registry publication; `v0.5.0` is the current stable release. All versions
+registry publication. Published packages are listed in
+[GitHub Releases](https://github.com/aimalygin/xray-rust/releases). All versions
 below 1.0 remain pre-1.0 in API and security maturity and do not imply a
 long-term supported release series.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "xray-bench"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "xray-cli"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "libc",
  "serde_json",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "xray-config"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "libc",
  "prost",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "xray-core-rs"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "xray-ffi"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "libc",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "xray-proxy"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "prost",
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "xray-routing"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "aho-corasick",
  "bytes",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "xray-runtime"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "thiserror",
  "tokio",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "xray-transport"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "xray-tun"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "thiserror",
@@ -2721,11 +2721,11 @@ dependencies = [
 
 [[package]]
 name = "xray-utls"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 
 [[package]]
 name = "xray-vless-encryption"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 dependencies = [
  "aes",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0-rc.1"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.96"
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Current stable release: [`v0.5.0`](https://github.com/aimalygin/xray-rust/releas
 Published release candidate: [`v0.6.0-rc.1`](https://github.com/aimalygin/xray-rust/releases/tag/v0.6.0-rc.1),
 with the matching [mobile SDK](https://github.com/aimalygin/xray-rust-mobile/releases/tag/v0.6.0-rc.1).
 See the [candidate evidence and coverage limits](docs/v06-release-evidence.md#published-v060-rc1).
+The owner has completed real-application RC checks and authorized
+[stable v0.6.0 preparation](docs/v06-stable-promotion.md).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ client runtime; its supported compatibility surface is documented below.
 
 This project is unofficial and is not affiliated with XTLS or Xray-core.
 
-Current stable release: [`v0.5.0`](https://github.com/aimalygin/xray-rust/releases/tag/v0.5.0).
+Stable source version: [`v0.6.0`](https://github.com/aimalygin/xray-rust/releases/tag/v0.6.0).
 Published release candidate: [`v0.6.0-rc.1`](https://github.com/aimalygin/xray-rust/releases/tag/v0.6.0-rc.1),
 with the matching [mobile SDK](https://github.com/aimalygin/xray-rust-mobile/releases/tag/v0.6.0-rc.1).
 See the [candidate evidence and coverage limits](docs/v06-release-evidence.md#published-v060-rc1).
 The owner has completed real-application RC checks and authorized
-[stable v0.6.0 preparation](docs/v06-stable-promotion.md).
+[stable v0.6.0 promotion](docs/v06-stable-promotion.md).
 
 ## Benchmarks
 

--- a/docs/config-contract.json
+++ b/docs/config-contract.json
@@ -45,7 +45,7 @@
       "semantics": "Requires address, port 1..65535 and explicit XHTTP method/network. A separate bounded stream is parsed with paths remapped to downloadSettings; recursive downloads, stream-one and chaining are unsupported."
     }
   ],
-  "coreVersion": "0.6.0-rc.1",
+  "coreVersion": "0.6.0",
   "documentation": "docs/config-tooling.md",
   "examples": {
     "dns-routing": {

--- a/docs/config-tooling.md
+++ b/docs/config-tooling.md
@@ -65,7 +65,7 @@ An accepted report has this shape (the core version follows the binary):
 ```json
 {
   "schemaVersion": 1,
-  "coreVersion": "0.6.0-rc.1",
+  "coreVersion": "0.6.0",
   "scope": "parser",
   "valid": true,
   "diagnostics": []

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,8 +4,9 @@ Status: living document, last reviewed 2026-09-08 (UTC).
 
 `v0.5.0` is the current stable release. Matching core and mobile
 `v0.6.0-rc.1` prereleases are published. Phases 1 and 2 below are retained as
-release history; Phase 3 is in RC stabilization before a separate stable
-release decision. This roadmap is not a
+release history; Phase 3 implementation and RC application acceptance are
+complete. The owner authorized stable `v0.6.0` publication on 2026-09-08;
+[final build and publication work](v06-stable-promotion.md) is in progress. This roadmap is not a
 promise that every conditional item will ship in the named release. Security,
 interoperability findings, and measured mobile behavior may reorder work.
 
@@ -306,9 +307,9 @@ will not be run as a retrospective or `v0.6` release gate.
   health, and structured diagnostic events. Do not add an in-core HTTP server.
 - Keep Android VLESS share-link import, statistics, and event coverage at
   parity with the supported portable Apple surface where platform APIs permit.
-- Add physical-device transition and soak coverage: Wi-Fi/cellular changes,
-  sleep/wake, memory pressure, extension/service restart, DNS64/NAT64,
-  cancellation, and long-lived XHTTP H2/H3 sessions.
+- Preserve the completed bounded Apple/Android device evidence and its
+  documented limits. Long device campaigns are excluded from the current
+  work list by owner decision on 2026-09-08.
 
 The version/capability foundation and cross-platform selection/health surface
 are implemented. A core-owned registry now supplies typed connection
@@ -414,8 +415,9 @@ VLESS 1-RTT/0-RTT with relay chains and padding, independent XHTTP downloads,
 mobile projection, and Milestone E configuration tooling. The exact-candidate
 release gates passed; see [published evidence](v06-release-evidence.md#published-v060-rc1).
 The [initial review and implementation plan](v06-implementation-plan.md)
-retains the baseline decision and delivery history. Stable promotion and
-registry publication remain separate from this RC completion.
+retains the baseline decision and delivery history. The owner confirmed real-app
+profile import, connect, disconnect and reconnect on 2026-09-08 and authorized
+[stable promotion and registry publication](v06-stable-promotion.md).
 
 Goal: add the modern VLESS encryption and client-policy capabilities with the
 same fail-closed configuration, pinned interoperability, and bounded mobile
@@ -565,14 +567,19 @@ regress.
 
 ### Release gates
 
-- Run bounded physical Apple and Android scenarios for the high-risk behavior
+The RC physical/performance gates below are completed, not outstanding tasks.
+Long device soak tests are absent from the current checklist. Stable promotion
+revalidates the original RC archive, verifies unchanged runtime/dependencies,
+and runs final automated gates on the stable revision.
+
+- Completed bounded physical Apple and Android scenarios for the high-risk behavior
   changed by `v0.6`: VLESS encryption, resolver-driven `IPOnDemand`, XHTTP
   download/session lifecycle, cancellation, and host adapter projection. There
   is no fixed six-hour minimum. Each report identifies the exact candidate,
   device and OS, scenario duration, transitions, traffic result, and explicit
   resource limits; simulator results cannot replace claimed device evidence.
   The candidate-bound archive format and submission procedure are documented
-  in `docs/v06-release-evidence.md`; the RC publication workflow revalidates
+  in `docs/v06-release-evidence.md`; the RC publication workflow revalidated
   that archive against the exact tagged commit and tree.
 - Keep the pinned interop, ASan/Miri/Loom, fuzz, controlled RTT/loss,
   supply-chain, Apple build, four-ABI Android, and clean performance gates
@@ -582,6 +589,10 @@ regress.
   evidence collection, not unfinished feature development.
 
 ### Exit criteria
+
+The selected Milestones A–E criteria are complete in the published RC.
+Only final stable builds and distribution remain; owner application
+acceptance is recorded in [stable promotion](v06-stable-promotion.md).
 
 - The selected Xray-core baseline, full commit, audit delta, regenerated
   fixtures, and blocking supported-surface interop results are published.
@@ -662,7 +673,7 @@ The roadmap is evaluated by outcomes, not only completed features:
 | Area | Measure |
 | --- | --- |
 | Compatibility | Blocking supported-surface interop against the exact stable Xray-core reference; scheduled early warning against upstream `main` |
-| Reliability | No unexplained memory/task growth or unrecoverable tunnel failure in transition, fault-injection, and extended device-soak tests |
+| Reliability | No unexplained memory/task growth or unrecoverable tunnel failure in bounded transition, fault-injection, and physical-device scenarios |
 | Security | Fuzz and dependency gates for parser/wire/FFI surfaces; tracked review of `unsafe`, secrets, and pinned forks; independent audit before a stable 1.0 claim |
 | Performance | Reproducible current-version results with raw provenance; no regression outside an explicitly justified budget |
 | Mobile SDK | Versioned capability discovery and equivalent essential lifecycle, selection, health, and diagnostic APIs on Apple and Android |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,11 +2,12 @@
 
 Status: living document, last reviewed 2026-09-08 (UTC).
 
-`v0.5.0` is the current stable release. Matching core and mobile
+The stable source version is `v0.6.0`. Matching core and mobile
 `v0.6.0-rc.1` prereleases are published. Phases 1 and 2 below are retained as
 release history; Phase 3 implementation and RC application acceptance are
 complete. The owner authorized stable `v0.6.0` publication on 2026-09-08;
-[final build and publication work](v06-stable-promotion.md) is in progress. This roadmap is not a
+[promotion record](v06-stable-promotion.md) describes final build gates and
+links to publication results. This roadmap is not a
 promise that every conditional item will ship in the named release. Security,
 interoperability findings, and measured mobile behavior may reorder work.
 
@@ -591,8 +592,8 @@ and runs final automated gates on the stable revision.
 ### Exit criteria
 
 The selected Milestones A–E criteria are complete in the published RC.
-Only final stable builds and distribution remain; owner application
-acceptance is recorded in [stable promotion](v06-stable-promotion.md).
+Owner application acceptance and the final stable build/distribution sequence
+are recorded in [stable promotion](v06-stable-promotion.md).
 
 - The selected Xray-core baseline, full commit, audit delta, regenerated
   fixtures, and blocking supported-surface interop results are published.

--- a/docs/status.md
+++ b/docs/status.md
@@ -11,7 +11,8 @@ been independently security audited. “Supported” below means implemented in
 this repository and covered by tests; it does not imply complete behavioral
 parity with every Xray-core release.
 
-Current stable packages are `v0.5.0`. The published candidate is
+The `v0.6.0` stable source preserves the runtime and dependencies of the
+published candidate
 [`v0.6.0-rc.1`](https://github.com/aimalygin/xray-rust/releases/tag/v0.6.0-rc.1),
 with the matching [mobile SDK](https://github.com/aimalygin/xray-rust-mobile/releases/tag/v0.6.0-rc.1).
 It adds `IPOnDemand` routing, bounded VLESS 1-RTT/0-RTT encryption with mixed
@@ -19,11 +20,13 @@ relay chains and configurable padding, independent XHTTP `downloadSettings`
 for packet-up/stream-up, and parser-backed configuration tooling. The full
 release CI and candidate-bound performance/physical-device gates passed.
 [Published evidence](v06-release-evidence.md#published-v060-rc1) records the
-exact revisions, artifacts and bounded coverage. This RC has not been promoted
-to the stable channel; its Android AAR is available from GitHub only.
+exact revisions, artifacts and bounded coverage. The original RC remains a
+GitHub-only prerelease; stable core/mobile publication results are available
+from [core v0.6.0](https://github.com/aimalygin/xray-rust/releases/tag/v0.6.0)
+and [mobile v0.6.0](https://github.com/aimalygin/xray-rust-mobile/releases/tag/v0.6.0).
 The owner confirmed real-application profile import, connect, disconnect and
 reconnect on 2026-09-08 and authorized [stable v0.6.0 publication](v06-stable-promotion.md).
-Final build/distribution work is in progress. Long device soak campaigns are
+Long device soak campaigns are
 removed from the current checklist; the completed bounded evidence remains
 recorded with its original RC identity.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -21,6 +21,11 @@ release CI and candidate-bound performance/physical-device gates passed.
 [Published evidence](v06-release-evidence.md#published-v060-rc1) records the
 exact revisions, artifacts and bounded coverage. This RC has not been promoted
 to the stable channel; its Android AAR is available from GitHub only.
+The owner confirmed real-application profile import, connect, disconnect and
+reconnect on 2026-09-08 and authorized [stable v0.6.0 publication](v06-stable-promotion.md).
+Final build/distribution work is in progress. Long device soak campaigns are
+removed from the current checklist; the completed bounded evidence remains
+recorded with its original RC identity.
 
 ## Runtime capabilities
 

--- a/docs/v06-release-evidence.md
+++ b/docs/v06-release-evidence.md
@@ -1,8 +1,11 @@
 # v0.6 release evidence
 
-The v0.6 release pipeline accepts only a bounded ZIP produced for the exact
-clean release-candidate commit. The authoritative schema and security checks
-are implemented by `scripts/check-v06-release-evidence.py`.
+The candidate path accepts a bounded ZIP produced for the exact clean
+release-candidate commit. Its schema and security checks are implemented by
+`scripts/check-v06-release-evidence.py`. The separately authorized
+[stable v0.6.0 promotion](v06-stable-promotion.md) validates that original ZIP
+and checks the stable source delta; it never rewrites the measured candidate
+identity or reports a new physical-device run.
 
 ## Published v0.6.0-rc.1
 
@@ -110,7 +113,9 @@ checksum file, manifest provenance and tagged licenses also matched.
 The RC is distributed through GitHub only; neither Maven Central nor GitHub
 Packages received an RC coordinate. Subsequent documentation/main integration
 does not retag these releases or transfer their device evidence to a different
-core commit. A changed candidate must follow the exact-source procedure below.
+core commit. Runtime/dependency changes require the exact-source procedure
+below; the separately checked version-only stable promotion retains original
+RC measurements and reports its source delta explicitly.
 
 ## Required evidence
 

--- a/docs/v06-release-evidence.md
+++ b/docs/v06-release-evidence.md
@@ -13,7 +13,7 @@ Matching [core](https://github.com/aimalygin/xray-rust/releases/tag/v0.6.0-rc.1)
 and [mobile SDK](https://github.com/aimalygin/xray-rust-mobile/releases/tag/v0.6.0-rc.1)
 prereleases are published; publication and public-consumer verification
 completed on 2026-09-08 UTC. The selected Milestones A–E scope is frozen.
-`v0.5.0` remains the stable release. This record closes the RC evidence work;
+At RC publication, `v0.5.0` was the stable release. This dated record closes the RC evidence work;
 it does not promote either package to stable or authorize registry publication.
 
 ### Exact source and automated gates

--- a/docs/v06-stable-promotion.md
+++ b/docs/v06-stable-promotion.md
@@ -1,9 +1,14 @@
 # v0.6.0 stable promotion
 
-Status: preparation and final automated verification in progress, authorized
-by the owner on 2026-09-08. The published packages remain `v0.6.0-rc.1` until
-stable release publication completes. Milestones A–E and RC distribution are
-complete; see [published RC evidence](v06-release-evidence.md#published-v060-rc1).
+Stable source version: `v0.6.0`, authorized by the owner on 2026-09-08.
+Milestones A–E, RC distribution and owner application acceptance are complete;
+see [published RC evidence](v06-release-evidence.md#published-v060-rc1).
+Publication results and final workflow links belong to the
+[core release](https://github.com/aimalygin/xray-rust/releases/tag/v0.6.0),
+[mobile release](https://github.com/aimalygin/xray-rust-mobile/releases/tag/v0.6.0)
+and [Maven Central coordinate](https://central.sonatype.com/artifact/io.github.aimalygin/xray-rust-mobile/0.6.0).
+This source record describes the promotion boundary; it does not by itself
+assert that pending workflows or distribution steps have completed.
 
 ## Application acceptance
 
@@ -40,7 +45,7 @@ stable commit from the measured candidate. Stable tag CI repeats that check.
 The mobile SDK still requires a successful evidence run/artifact bound to
 its exact locked stable core commit and tree.
 
-## Remaining release work
+## Publication sequence
 
 - Run the full automated core release matrix on the final stable revision and
   publish the annotated source-only `v0.6.0` GitHub release after it passes.

--- a/docs/v06-stable-promotion.md
+++ b/docs/v06-stable-promotion.md
@@ -1,0 +1,56 @@
+# v0.6.0 stable promotion
+
+Status: preparation and final automated verification in progress, authorized
+by the owner on 2026-09-08. The published packages remain `v0.6.0-rc.1` until
+stable release publication completes. Milestones A–E and RC distribution are
+complete; see [published RC evidence](v06-release-evidence.md#published-v060-rc1).
+
+## Application acceptance
+
+On 2026-09-08 the owner reported completing the proposed real-application RC
+checks: profile import, connect, disconnect and reconnect. No corrective issue
+was reported in that acceptance message. The application, platform and raw
+logs were not supplied; this is an owner report, not an additional instrumented
+device campaign or automated test result.
+
+The owner also removed long device soak checks from the current work list.
+The completed bounded iPhone 13 and Samsung campaigns remain the device
+evidence. Their exclusions and resource limits remain unchanged.
+
+## Source and evidence boundary
+
+The measured core remains commit `1e713ca3e6c57be5747b4915b31e0db040a01c0c`,
+tree `69fe0a56ce5bcbd178d8326e32d15dfab660b99c`, annotated RC tag object
+`3578dda8475198f19d6be97f310769c36794e9e1`. Its
+[public evidence ZIP](https://raw.githubusercontent.com/aimalygin/xray-rust/278d4d2324a689815641ec2d13acdc8e0244ec28/v06-release-evidence.zip)
+has SHA-256 `5dab7e06b72af9a8fef1524a7271afe97ca8ff0df893c46a8ab7678921cec490`.
+
+`scripts/check-v06-stable-promotion.py` verifies the original ZIP and exact
+RC tag, commit and tree. It requires a clean stable checkout descended from
+that RC. All runtime, adapter, build and dependency files must match the RC;
+only an explicit list of documentation/release-tooling files may differ.
+`Cargo.toml` may change only the workspace version, `Cargo.lock` only matching
+workspace-package versions, and the generated contract only `coreVersion`.
+New source files, compiler flags, dependency changes, removed files and file
+mode changes are rejected. The original exact-candidate validator is unchanged.
+
+The existing `v0.6 release evidence` workflow runs on the stable source and
+retains the original RC archive plus a validation report distinguishing the
+stable commit from the measured candidate. Stable tag CI repeats that check.
+The mobile SDK still requires a successful evidence run/artifact bound to
+its exact locked stable core commit and tree.
+
+## Remaining release work
+
+- Run the full automated core release matrix on the final stable revision and
+  publish the annotated source-only `v0.6.0` GitHub release after it passes.
+- Pin the mobile SDK to that stable core tag/commit/tree and prepare the
+  canonical Apple archive, checksum PR and final Apple/Android release tests.
+- Publish the immutable mobile GitHub release and GitHub Packages mirror,
+  then the signed `io.github.aimalygin:xray-rust-mobile:0.6.0` Maven Central
+  coordinate through the protected publishing environment.
+- Verify public hashes/provenance and clean SwiftPM/Maven Central consumers.
+
+Publication is authorized by the owner. Required GitHub reviewer/environment
+approvals remain explicit checks; previous one-time PR review bypasses do not
+apply to new PRs. Existing RC tags and assets must remain unchanged.

--- a/scripts/check-v06-release-evidence.sh
+++ b/scripts/check-v06-release-evidence.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+[[ "$#" -eq 3 ]] || { echo "usage: $0 <evidence.zip> <commit> <tree>" >&2; exit 2; }
+
+if grep -Fxq 'version = "0.6.0"' "$ROOT/Cargo.toml"; then
+  python3 "$ROOT/scripts/check-v06-stable-promotion.py" "$@"
+else
+  python3 "$ROOT/scripts/check-v06-release-evidence.py" "$@"
+fi

--- a/scripts/check-v06-stable-promotion.py
+++ b/scripts/check-v06-stable-promotion.py
@@ -43,6 +43,7 @@ NON_RUNTIME_FILES = {
     "scripts/check-v06-release-evidence.sh",
     "scripts/tests/test_v06_stable_promotion.py",
     "scripts/tests/check-prerelease-workflow.test.sh",
+    "scripts/tests/check-scheduled-interop-workflow.test.sh",
 }
 VERSIONED_FILES = {"Cargo.toml", "Cargo.lock", "docs/config-contract.json"}
 

--- a/scripts/check-v06-stable-promotion.py
+++ b/scripts/check-v06-stable-promotion.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Verify v0.6.0 promotion without relabeling the RC's device measurements."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tomllib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RC_TAG = "v0.6.0-rc.1"
+RC_TAG_OBJECT = "3578dda8475198f19d6be97f310769c36794e9e1"
+RC_COMMIT = "1e713ca3e6c57be5747b4915b31e0db040a01c0c"
+RC_TREE = "69fe0a56ce5bcbd178d8326e32d15dfab660b99c"
+RC_EVIDENCE_SHA256 = "5dab7e06b72af9a8fef1524a7271afe97ca8ff0df893c46a8ab7678921cec490"
+RC_VERSION = "0.6.0-rc.1"
+STABLE_VERSION = "0.6.0"
+
+# An explicit list: new runtime files, dependencies, build scripts, adapters,
+# compiler settings, and ABI changes require fresh candidate evidence.
+NON_RUNTIME_FILES = {
+    "README.md",
+    "CHANGELOG.md",
+    "docs/roadmap.md",
+    "docs/status.md",
+    "docs/v06-candidate-review.md",
+    "docs/v06-implementation-plan.md",
+    "docs/v06-independent-security-review.md",
+    "docs/v06-release-evidence.md",
+    "docs/v06-stable-promotion.md",
+    "docs/verification.md",
+    "docs/vless-encryption-design.md",
+    "docs/xhttp-download-design.md",
+    "docs/config-tooling.md",
+    ".github/workflows/ci.yml",
+    ".github/workflows/v06-release-evidence.yml",
+    "scripts/check-v06-stable-promotion.py",
+    "scripts/check-v06-release-evidence.sh",
+    "scripts/tests/test_v06_stable_promotion.py",
+    "scripts/tests/check-prerelease-workflow.test.sh",
+}
+VERSIONED_FILES = {"Cargo.toml", "Cargo.lock", "docs/config-contract.json"}
+
+SPEC = importlib.util.spec_from_file_location(
+    "rc_evidence", ROOT / "scripts/check-v06-release-evidence.py"
+)
+assert SPEC and SPEC.loader
+EVIDENCE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(EVIDENCE)
+
+
+def git(root: pathlib.Path, *args: str) -> bytes:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True
+    ).stdout
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def entries(root: pathlib.Path, revision: str) -> dict[str, tuple[str, str]]:
+    result = {}
+    for entry in git(root, "ls-tree", "-rz", revision).split(b"\0"):
+        if entry:
+            metadata, name = entry.split(b"\t", 1)
+            mode, kind, oid = metadata.decode().split()
+            result[name.decode()] = (mode + " " + kind, oid)
+    return result
+
+
+def validate_version_change(name: str, before: bytes, after: bytes) -> None:
+    if name == "Cargo.toml":
+        old = f'version = "{RC_VERSION}"'.encode()
+        new = f'version = "{STABLE_VERSION}"'.encode()
+        require(before.count(old) == 1, "ambiguous workspace version")
+        require(after == before.replace(old, new), "Cargo.toml changes exceed the version bump")
+    elif name == "Cargo.lock":
+        expected = tomllib.loads(before.decode())
+        for package in expected["package"]:
+            if "source" not in package and package["version"] == RC_VERSION:
+                require(package["name"].startswith("xray-"), "unexpected workspace package")
+                package["version"] = STABLE_VERSION
+        require(tomllib.loads(after.decode()) == expected, "Cargo.lock changes dependencies")
+    elif name == "docs/config-contract.json":
+        expected = json.loads(before)
+        require(expected["coreVersion"] == RC_VERSION, "unexpected contract version")
+        expected["coreVersion"] = STABLE_VERSION
+        require(json.loads(after) == expected, "configuration contract changes exceed the version bump")
+
+
+def validate_source(root: pathlib.Path, revision: str, tree: str) -> list[str]:
+    require(bool(EVIDENCE.SHA40.fullmatch(revision)), "invalid stable commit")
+    require(bool(EVIDENCE.SHA40.fullmatch(tree)), "invalid stable tree")
+    require(git(root, "rev-parse", "HEAD").decode().strip() == revision, "stable commit is not HEAD")
+    require(git(root, "rev-parse", "HEAD^{tree}").decode().strip() == tree, "stable tree differs")
+    require(not git(root, "status", "--porcelain", "--untracked-files=normal"), "stable checkout is dirty")
+    require(git(root, "rev-parse", f"refs/tags/{RC_TAG}^{{tag}}").decode().strip() == RC_TAG_OBJECT, "RC tag object differs")
+    require(git(root, "rev-parse", f"refs/tags/{RC_TAG}^{{commit}}").decode().strip() == RC_COMMIT, "RC commit differs")
+    require(git(root, "rev-parse", f"{RC_COMMIT}^{{tree}}").decode().strip() == RC_TREE, "RC tree differs")
+    git(root, "merge-base", "--is-ancestor", RC_COMMIT, revision)
+    before, after = entries(root, RC_COMMIT), entries(root, revision)
+    changed = sorted(name for name in before.keys() | after.keys() if before.get(name) != after.get(name))
+    require(VERSIONED_FILES <= set(changed), "stable version metadata is incomplete")
+    for name in changed:
+        require(name in NON_RUNTIME_FILES | VERSIONED_FILES, f"runtime or unapproved file changed: {name}")
+        require(name in after, f"promotion deletes a file: {name}")
+        require(after[name][0] in {"100644 blob", "100755 blob"}, f"not a regular file: {name}")
+        if name in before:
+            require(before[name][0] == after[name][0], f"file mode changed: {name}")
+        if name in VERSIONED_FILES:
+            validate_version_change(name, git(root, "show", f"{RC_COMMIT}:{name}"), git(root, "show", f"{revision}:{name}"))
+    return changed
+
+
+def validate(root: pathlib.Path, archive: pathlib.Path, revision: str, tree: str) -> dict:
+    require(archive.stat().st_size <= EVIDENCE.MAX_ARCHIVE_BYTES, "RC evidence exceeds size limit")
+    require(hashlib.sha256(archive.read_bytes()).hexdigest() == RC_EVIDENCE_SHA256, "published RC evidence checksum differs")
+    EVIDENCE.validate_archive(archive, RC_COMMIT, RC_TREE)
+    changed = validate_source(root, revision, tree)
+    return {
+        "schemaVersion": 1,
+        "kind": "v0.6.0-stable-promotion",
+        "stable": {"revision": revision, "tree": tree, "dirty": False},
+        "measuredCandidate": {"revision": RC_COMMIT, "tree": RC_TREE, "tagObject": RC_TAG_OBJECT},
+        "rcEvidenceSha256": RC_EVIDENCE_SHA256,
+        "changedFiles": changed,
+        "runtimeAndDependenciesUnchanged": True,
+        "newPhysicalDeviceRun": False,
+        "longSoakRequired": False,
+        "result": "pass",
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(f"usage: {sys.argv[0]} <published-rc-evidence.zip> <stable-commit> <stable-tree>", file=sys.stderr)
+        return 2
+    try:
+        report = validate(ROOT, pathlib.Path(sys.argv[1]), sys.argv[2], sys.argv[3])
+    except (OSError, ValueError, subprocess.CalledProcessError, EVIDENCE.ValidationError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/check-prerelease-workflow.test.sh
+++ b/scripts/tests/check-prerelease-workflow.test.sh
@@ -215,7 +215,7 @@ check_classification() {
 }
 
 check_classification push refs/tags/v0.6.0-rc.1 true true
-check_classification push refs/tags/v0.6.0 false false
+check_classification push refs/tags/v0.6.0 false true
 check_classification push refs/heads/codex/v06-candidate false true
 check_classification push refs/heads/v0.6.0-rc.1 false false
 check_classification push refs/heads/main false false
@@ -228,9 +228,14 @@ for job in rc-interop host-hardening fuzz-smoke controlled-network; do
   grep -Fxq "    if: needs.release-metadata.outputs.run_release_gates == 'true'" <<<"$(job_body "$job")" || \
     die "$job is not enabled for candidate verification"
 done
-for job in release-evidence publish-prerelease; do
+for job in publish-prerelease; do
   grep -Fxq "    if: needs.release-metadata.outputs.is_rc == 'true'" <<<"$(job_body "$job")" || \
     die "$job is not restricted to RC tag publication"
 done
+
+grep -Fxq "    if: needs.release-metadata.outputs.is_rc == 'true' || github.ref == 'refs/tags/v0.6.0'" <<<"$(job_body release-evidence)" || \
+  die "stable v0.6.0 is not gated on release evidence"
+grep -Fq 'bash scripts/check-v06-release-evidence.sh' <<<"$(job_body release-evidence)" || \
+  die "release boundary does not revalidate candidate or promotion evidence"
 
 echo "verified idempotent source-only prerelease workflow policy and candidate isolation"

--- a/scripts/tests/check-scheduled-interop-workflow.test.sh
+++ b/scripts/tests/check-scheduled-interop-workflow.test.sh
@@ -377,7 +377,7 @@ expected_rust="$(cat <<'EXPECTED'
           bash scripts/tests/check-v05-performance.test.sh
           bash scripts/tests/check-v05-host-hardening.test.sh
           bash scripts/tests/check-mobile-device-evidence.test.sh
-          python3 -m unittest scripts.tests.test_v06_release_evidence
+          python3 -m unittest scripts.tests.test_v06_release_evidence scripts.tests.test_v06_stable_promotion
           bash scripts/tests/bench-xhttp-memory.test.sh
           if [[ -f docs/benchmarks/results/2026-08-29-v26.7.28/manifest.json ]]; then
             python3 scripts/check-benchmark-publication.py docs/benchmarks/results/2026-08-29-v26.7.28

--- a/scripts/tests/test_v06_stable_promotion.py
+++ b/scripts/tests/test_v06_stable_promotion.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.tests import test_v06_release_evidence as evidence_fixtures
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "promotion", ROOT / "scripts/check-v06-stable-promotion.py"
+)
+assert SPEC and SPEC.loader
+PROMOTION = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROMOTION)
+
+
+class StablePromotionTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name) / "repo"
+        self.root.mkdir()
+        self.git("init", "-q")
+        self.git("config", "user.name", "Release fixture")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.write("Cargo.toml", '[workspace.package]\nversion = "0.6.0-rc.1"\n[workspace.dependencies]\nbytes = "1"\n')
+        self.write("Cargo.lock", 'version = 4\n[[package]]\nname = "xray-config"\nversion = "0.6.0-rc.1"\n[[package]]\nname = "bytes"\nversion = "1.0.0"\nsource = "registry+https://example.invalid"\nchecksum = "abc"\n')
+        self.write("docs/config-contract.json", '{"coreVersion":"0.6.0-rc.1","supported":["vless"]}')
+        self.write("crates/xray-config/src/lib.rs", "pub const VALUE: u8 = 1;\n")
+        self.write("README.md", "Candidate\n")
+        self.commit()
+        self.rc = self.git("rev-parse", "HEAD")
+        self.tree = self.git("rev-parse", "HEAD^{tree}")
+        self.git("tag", "-a", PROMOTION.RC_TAG, "-m", "candidate")
+        self.tag_object = self.git("rev-parse", f"{PROMOTION.RC_TAG}^{{tag}}")
+        for name in PROMOTION.VERSIONED_FILES:
+            p = self.root / name
+            p.write_text(p.read_text().replace("0.6.0-rc.1", "0.6.0"))
+        self.write("docs/v06-stable-promotion.md", "Owner accepted RC application checks.\n")
+        self.commit()
+        for name, value in {"RC_COMMIT": self.rc, "RC_TREE": self.tree, "RC_TAG_OBJECT": self.tag_object}.items():
+            mock = patch.object(PROMOTION, name, value)
+            mock.start()
+            self.addCleanup(mock.stop)
+
+    def git(self, *args):
+        return subprocess.run(["git", "-C", str(self.root), *args], check=True, capture_output=True, text=True).stdout.strip()
+
+    def write(self, name, text):
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    def commit(self):
+        self.git("add", ".")
+        self.git("commit", "-qm", "fixture")
+
+    def validate(self, **overrides):
+        return PROMOTION.validate_source(
+            self.root,
+            overrides.get("revision", self.git("rev-parse", "HEAD")),
+            overrides.get("tree", self.git("rev-parse", "HEAD^{tree}")),
+        )
+
+    def test_metadata_only_promotion(self):
+        self.assertIn("Cargo.lock", self.validate())
+
+    def test_runtime_edit_is_rejected(self):
+        self.write("crates/xray-config/src/lib.rs", "pub const VALUE: u8 = 2;\n")
+        self.commit()
+        with self.assertRaisesRegex(ValueError, "runtime or unapproved"):
+            self.validate()
+
+    def test_new_build_script_is_rejected(self):
+        self.write("build.rs", "fn main() {}\n")
+        self.commit()
+        with self.assertRaisesRegex(ValueError, "runtime or unapproved"):
+            self.validate()
+
+    def test_dependency_edit_is_rejected(self):
+        path = self.root / "Cargo.lock"
+        path.write_text(path.read_text().replace('version = "1.0.0"', 'version = "1.1.0"'))
+        self.commit()
+        with self.assertRaisesRegex(ValueError, "changes dependencies"):
+            self.validate()
+
+    def test_compiler_or_manifest_edit_is_rejected(self):
+        path = self.root / "Cargo.toml"
+        path.write_text(path.read_text() + '[profile.release]\npanic = "abort"\n')
+        self.commit()
+        with self.assertRaisesRegex(ValueError, "Cargo.toml changes exceed"):
+            self.validate()
+
+    def test_config_contract_drift_is_rejected(self):
+        self.write("docs/config-contract.json", '{"coreVersion":"0.6.0","supported":["vmess"]}')
+        self.commit()
+        with self.assertRaisesRegex(ValueError, "contract changes exceed"):
+            self.validate()
+
+    def test_dirty_checkout_is_rejected(self):
+        self.write("README.md", "uncommitted\n")
+        with self.assertRaisesRegex(ValueError, "dirty"):
+            self.validate()
+
+    def test_mismatched_head_or_tree_is_rejected(self):
+        for overrides in [{"revision": self.rc}, {"tree": self.tree}]:
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                self.validate(**overrides)
+
+    def test_moved_rc_tag_is_rejected(self):
+        self.git("tag", "-f", "-a", PROMOTION.RC_TAG, "-m", "moved")
+        with self.assertRaisesRegex(ValueError, "RC tag object differs"):
+            self.validate()
+
+    def test_mode_change_is_rejected(self):
+        (self.root / "README.md").chmod(0o755)
+        self.commit()
+        with self.assertRaisesRegex(ValueError, "file mode changed"):
+            self.validate()
+
+    def test_symlink_is_rejected(self):
+        (self.root / "README.md").unlink()
+        (self.root / "README.md").symlink_to("Cargo.toml")
+        self.commit()
+        with self.assertRaisesRegex(ValueError, "not a regular file"):
+            self.validate()
+
+    def test_archive_remains_bound_to_measured_rc(self):
+        manifest, blobs = evidence_fixtures.V06ReleaseEvidenceTests().evidence()
+        manifest["candidate"].update(revision=self.rc, tree=self.tree)
+        archive = self.root.parent / "rc.zip"
+        with zipfile.ZipFile(archive, "w") as output:
+            output.writestr("manifest.json", json.dumps(manifest))
+            for name, blob in blobs.items():
+                output.writestr(name, blob)
+        digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        revision, tree = self.git("rev-parse", "HEAD"), self.git("rev-parse", "HEAD^{tree}")
+        with patch.object(PROMOTION, "RC_EVIDENCE_SHA256", digest):
+            report = PROMOTION.validate(self.root, archive, revision, tree)
+            self.assertEqual(report["measuredCandidate"]["revision"], self.rc)
+            self.assertEqual(report["stable"]["revision"], revision)
+            self.assertFalse(report["newPhysicalDeviceRun"])
+            archive.write_bytes(archive.read_bytes() + b"changed")
+            with self.assertRaisesRegex(ValueError, "checksum differs"):
+                PROMOTION.validate(self.root, archive, revision, tree)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_v06_stable_promotion.py
+++ b/scripts/tests/test_v06_stable_promotion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import subprocess
 import tempfile
 import unittest
@@ -151,6 +152,45 @@ class StablePromotionTests(unittest.TestCase):
             archive.write_bytes(archive.read_bytes() + b"changed")
             with self.assertRaisesRegex(ValueError, "checksum differs"):
                 PROMOTION.validate(self.root, archive, revision, tree)
+
+    def test_workflow_propagates_validator_failure(self):
+        # Run the real workflow shell with GitHub's default bash -e behavior.
+        # A logging pipe must not convert a rejected archive into success.
+        lines = (ROOT / ".github/workflows/v06-release-evidence.yml").read_text().splitlines()
+        start = lines.index("      - name: Download and validate exact-candidate evidence")
+        start = lines.index("        run: |", start) + 1
+        commands = []
+        for line in lines[start:]:
+            if line.startswith("          "):
+                commands.append(line[10:])
+            elif not line:
+                commands.append("")
+            else:
+                break
+        self.write("scripts/check-v06-release-evidence.sh", "exit 17\n")
+        fake_bin = self.root / "fake-bin"
+        fake_bin.mkdir()
+        for name, body in {
+            "curl": ': > "$RUNNER_TEMP/v06-release-evidence.zip"',
+            "sha256sum": "cat >/dev/null",
+            "git": "printf '%040d\\n' 0",
+        }.items():
+            path = fake_bin / name
+            path.write_text("#!/bin/sh\n" + body + "\n")
+            path.chmod(0o755)
+        env = os.environ.copy()
+        env.update(
+            PATH=str(fake_bin) + os.pathsep + env["PATH"],
+            RUNNER_TEMP=str(self.root),
+            GITHUB_SHA="1" * 40,
+            EVIDENCE_URL="https://example.invalid/evidence.zip",
+            EVIDENCE_SHA256="0" * 64,
+        )
+        result = subprocess.run(
+            ["bash", "-e", "-c", "\n".join(commands)],
+            cwd=self.root, env=env, capture_output=True, text=True,
+        )
+        self.assertEqual(result.returncode, 17, result.stdout + result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Prepares the completed v0.6 scope for stable release: workspace/package versions and the generated contract become 0.6.0, roadmap/status record completed RC acceptance, and long device soak campaigns leave the current checklist at the owner’s request. Adds a bounded promotion verifier that checks the original published RC archive without rewriting its measured commit/tree. It requires RC ancestry and rejects runtime, adapter, dependency, compiler-setting, file-mode and configuration-contract changes beyond the version bump. Stable tags run the full automated release gates; v0.6.0 revalidates promotion evidence at the release boundary.

## Verification

- All 20 evidence/promotion cases passed, including negative source, dependency, archive, tag, mode and identity cases. A regression executes the actual workflow shell and proves validator failures remain failures when saving logs.
- All six [PR CI jobs](https://github.com/aimalygin/xray-rust/actions/runs/34237904921) passed on `8fd695d3da7ae98051b55b598aa7a16c8ecb1db5`: Rust, Android, Apple, go-oracles, secrets and supply-chain. Apple includes 299 passing Swift tests, adapter links and sample app builds. The stable tag must pass the full release matrix before GitHub release publication.
- The full repository-script CI step and Rust lint/test/API-doc checks passed. All four configuration-tooling tests passed with the generated 0.6.0 contract.
- Original public RC evidence passed promotion validation on clean head `8fd695d3da7ae98051b55b598aa7a16c8ecb1db5`; [GitHub evidence validation](https://github.com/aimalygin/xray-rust/actions/runs/34238041953) passed.
- GitHub’s test merge preserves the exact reviewed candidate tree and RC ancestry.
- No new performance or physical-device campaign is claimed; owner-reported real-app acceptance is labeled separately.

## Compatibility and security

The runtime, dependency set, Swift/Kotlin adapters and C ABI remain identical to v0.6.0-rc.1. Published RC tags/assets stay unchanged. The original exact-candidate validator remains unchanged. Existing one-time review bypasses are not extended to this PR; stable publication follows final gates and required approvals.