### PR TITLE
Raise bounded GeoIP budgets for large country datasets

### DIFF
--- a/crates/xray-config/src/geodata.rs
+++ b/crates/xray-config/src/geodata.rs
@@ -22,7 +22,7 @@ const MAX_GEODATA_DOMAINS: usize = 200_000;
 const MAX_GEODATA_DOMAIN_ATTRIBUTES: usize = 400_000;
 const MAX_GEODATA_DOMAIN_VALUE_SIZE: usize = 4 * 1024;
 const MAX_GEODATA_ATTRIBUTE_SIZE: usize = 1024;
-const MAX_GEODATA_CIDRS: usize = 250_000;
+const MAX_GEODATA_CIDRS: usize = 500_000;
 const MAX_GEODATA_CIDR_SIZE: usize = 128;
 
 #[derive(Debug)]

--- a/crates/xray-config/src/parser.rs
+++ b/crates/xray-config/src/parser.rs
@@ -41,8 +41,8 @@ const MAX_DNS_OUTBOUND_RULES: usize = 4_096;
 const MAX_DNS_QTYPE_SELECTORS: usize = 65_536;
 const MAX_ROUTING_PORT_SELECTORS: usize = 65_536;
 pub const MAX_CONFIG_DOMAIN_MATCHERS: usize = 250_000;
-const MAX_CONFIG_IP_MATCHERS: usize = 300_000;
-const MAX_CONFIG_MATCHERS: usize = 500_000;
+const MAX_CONFIG_IP_MATCHERS: usize = 750_000;
+const MAX_CONFIG_MATCHERS: usize = 1_000_000;
 const MAX_CONFIG_GEODATA_ATTR_FILTERS: usize = 32;
 const MAX_CONFIG_GEODATA_ATTRIBUTE_SIZE: usize = 256;
 const MAX_DNS_SERVERS: usize = 8;
@@ -2613,11 +2613,28 @@ mod tests {
 
         assert!(domain_budget.consume_domain_matchers(250_000));
         assert!(!domain_budget.consume_domain_matchers(1));
-        assert!(ip_budget.consume_ip_matchers(300_000));
+        assert!(ip_budget.consume_ip_matchers(750_000));
         assert!(!ip_budget.consume_ip_matchers(1));
-        assert!(combined_budget.consume_domain_matchers(200_000));
-        assert!(combined_budget.consume_ip_matchers(300_000));
+        assert!(combined_budget.consume_domain_matchers(250_000));
+        assert!(combined_budget.consume_ip_matchers(750_000));
+        assert_eq!(combined_budget.remaining_total_matchers(), 0);
         assert!(!combined_budget.consume_domain_matchers(1));
+        assert!(!combined_budget.consume_ip_matchers(1));
+    }
+
+    #[test]
+    fn combined_matcher_budget_can_be_stricter_than_individual_limits() {
+        let mut budget = MatcherBudget::new(MatcherBudgetLimits {
+            domain_matchers: 3,
+            ip_matchers: 3,
+            total_matchers: 4,
+            ..DEFAULT_MATCHER_BUDGET_LIMITS
+        });
+
+        assert!(budget.consume_domain_matchers(2));
+        assert!(budget.consume_ip_matchers(2));
+        assert!(!budget.consume_domain_matchers(1));
+        assert!(!budget.consume_ip_matchers(1));
     }
 
     #[test]

--- a/crates/xray-config/tests/geoip_budget_tests.rs
+++ b/crates/xray-config/tests/geoip_budget_tests.rs
@@ -1,0 +1,157 @@
+use std::{
+    fs,
+    net::{IpAddr, Ipv6Addr},
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use prost::Message;
+use serde_json::json;
+use xray_config::parse_xray_json_with_geodata_dirs;
+
+// Loyalsoldier's 202609082347 snapshot has this many CIDRs in geoip:us.
+// Generate documentation-only addresses instead of checking in that database.
+const LARGE_COUNTRY_CIDRS: usize = 300_531;
+
+#[test]
+fn large_geoip_category_can_be_used_by_two_routing_rules() {
+    let fixture = GeoIpFixture::new(LARGE_COUNTRY_CIDRS);
+    let parsed =
+        parse_xray_json_with_geodata_dirs(&routing_config(2), std::slice::from_ref(&fixture.dir))
+            .expect("a US-sized category should fit both routing rules");
+
+    assert_eq!(parsed.config.routing.rules.len(), 2);
+    assert!(parsed.diagnostics.is_empty());
+    for rule in &parsed.config.routing.rules {
+        assert!(rule.matches_ip(Some(&IpAddr::V6(documentation_ip(0)))));
+        assert!(rule.matches_ip(Some(&IpAddr::V6(documentation_ip(LARGE_COUNTRY_CIDRS - 1)))));
+        assert!(!rule.matches_ip(Some(&IpAddr::V6(documentation_ip(LARGE_COUNTRY_CIDRS)))));
+        assert!(!rule.matches_ip(Some(&IpAddr::V6("2001:db8::1".parse().unwrap()))));
+    }
+}
+
+#[test]
+fn repeated_large_geoip_categories_still_exhaust_the_config_budget() {
+    let fixture = GeoIpFixture::new(LARGE_COUNTRY_CIDRS);
+    let error =
+        parse_xray_json_with_geodata_dirs(&routing_config(3), std::slice::from_ref(&fixture.dir))
+            .expect_err("three US-sized expansions exceed the 750,000-IP budget");
+
+    assert!(
+        error.diagnostics.iter().any(|diagnostic| {
+            diagnostic.path.as_deref() == Some("$.routing.rules[2].ip[0]")
+                && diagnostic.message.contains("IP matchers")
+                && diagnostic.message.contains("148938 slots remain")
+        }),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn geoip_category_above_the_cidr_limit_is_rejected() {
+    let fixture = GeoIpFixture::new(500_001);
+    let error =
+        parse_xray_json_with_geodata_dirs(&routing_config(1), std::slice::from_ref(&fixture.dir))
+            .expect_err("the per-category CIDR ceiling must still be enforced");
+
+    assert!(
+        error.diagnostics.iter().any(|diagnostic| {
+            diagnostic.path.as_deref() == Some("$.routing.rules[0].ip[0]")
+                && diagnostic.message.contains("more than 500000 CIDRs")
+        }),
+        "{error:?}"
+    );
+}
+
+fn routing_config(rule_count: usize) -> String {
+    let inbounds = (0..rule_count)
+        .map(|index| {
+            json!({
+                "tag": format!("in-{index}"), "protocol": "socks",
+                "listen": "127.0.0.1", "port": 1080 + index
+            })
+        })
+        .collect::<Vec<_>>();
+    let rules = (0..rule_count)
+        .map(|index| {
+            json!({
+                "type": "field", "inboundTag": [format!("in-{index}")],
+                "ip": ["geoip:large"], "outboundTag": "direct"
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "inbounds": inbounds,
+        "outbounds": [{"tag": "direct", "protocol": "freedom"}],
+        "routing": {"rules": rules}
+    })
+    .to_string()
+}
+
+fn documentation_ip(index: usize) -> Ipv6Addr {
+    let mut address = [0u8; 16];
+    address[..4].copy_from_slice(&[0x20, 0x01, 0x0d, 0xb8]);
+    // Leave holes so the compiled matcher cannot merge the whole category.
+    address[8..].copy_from_slice(&(index as u64 * 2).to_be_bytes());
+    Ipv6Addr::from(address)
+}
+
+struct GeoIpFixture {
+    dir: PathBuf,
+}
+
+impl GeoIpFixture {
+    fn new(cidr_count: usize) -> Self {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("xray-geoip-budget-{}-{stamp}", std::process::id()));
+        fs::create_dir(&dir).unwrap();
+        let fixture = Self { dir };
+        let body = Country {
+            code: "LARGE".to_owned(),
+            cidr: (0..cidr_count)
+                .map(|index| Cidr {
+                    ip: documentation_ip(index).octets().to_vec(),
+                    prefix: 128,
+                })
+                .collect(),
+        }
+        .encode_to_vec();
+        // GeoIPList.entry is a length-delimited protobuf field, as in the real snapshot.
+        let mut data = vec![0x0a];
+        let mut length = body.len() as u64;
+        while length >= 0x80 {
+            data.push(length as u8 | 0x80);
+            length >>= 7;
+        }
+        data.push(length as u8);
+        data.extend_from_slice(&body);
+        fs::write(fixture.dir.join("geoip.dat"), data).unwrap();
+        fixture
+    }
+}
+
+impl Drop for GeoIpFixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct Country {
+    #[prost(string, tag = "1")]
+    code: String,
+    #[prost(message, repeated, tag = "2")]
+    cidr: Vec<Cidr>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct Cidr {
+    #[prost(bytes = "vec", tag = "1")]
+    ip: Vec<u8>,
+    #[prost(uint32, tag = "2")]
+    prefix: u32,
+}

--- a/docs/config-compatibility.md
+++ b/docs/config-compatibility.md
@@ -1527,6 +1527,18 @@ File names must be relative and cannot escape a configured search directory.
 Parsing enforces file, entry, matcher, rule, attribute, domain, and CIDR budgets
 to bound untrusted input.
 
+A selected GeoIP entry may contain up to 500,000 CIDRs. The entry is checked
+before protobuf decoding. Every expansion is charged against the shared
+per-configuration IP and total matcher budgets, including repeated references
+to a cached category in different rules or DNS selectors.
+
+This allows large current country sets: for example, Loyalsoldier's
+[202609082347 snapshot](https://github.com/Loyalsoldier/v2ray-rules-dat/releases/tag/202609082347)
+contains 300,531 CIDRs in `geoip:us`, exceeding the earlier limits of 250,000
+CIDRs per category and 300,000 IP matchers per configuration. Raising these
+ceilings increases the maximum parsing work and routing state a configuration
+can request. File-size, entry-size, path, and other resource checks still apply.
+
 ## Diagnostics
 
 Parser errors include JSON paths. Warnings do not fail a load; callers should
@@ -1535,6 +1547,6 @@ display them. The C ABI exposes warnings through
 them through their platform logging paths.
 
 Current aggregate limits include 4,096 routing rules, 250,000 domain matchers,
-300,000 IP matchers, and 500,000 matchers total per config. These limits are
+750,000 IP matchers, and 1,000,000 matchers total per config. These limits are
 implementation safeguards and may change across major ABI or documented
 configuration revisions.


### PR DESCRIPTION
## Summary

A configuration referencing `geoip:us` from Loyalsoldier snapshot `202609082347` fails to load: the category contains **300,531 CIDRs**, exceeding the current per-category limit of 250,000. The parser reports `geoip contains more than 250000 CIDRs`. Raising only that limit still leaves the configuration above the 300,000-IP matcher budget.

This compatibility fix raises three bounded limits:

| Limit | Before | After |
| --- | ---: | ---: |
| CIDRs per GeoIP category | 250,000 | 500,000 |
| IP matchers per configuration | 300,000 | 750,000 |
| Combined domain/IP matchers per configuration | 500,000 | 1,000,000 |

The 750,000-IP budget allows a category of this size to be referenced by two rules for different inbounds, consuming 601,062 matchers. The combined ceiling accommodates that IP budget plus the existing 250,000-domain limit.

## Verification

- [x] Added regression tests and updated the existing default-limit test.
- [x] Ran formatting, strict Clippy, and the full workspace test suite.
- [x] Updated compatibility documentation.
- [x] Used only synthetic endpoints and credentials in committed tests.
- Benchmarks: not applicable; this PR makes no performance claims.

Three integration tests generate temporary protobuf databases using addresses from `2001:db8::/32`, without downloading or committing a real database:

- A category with 300,531 CIDRs can be used by two routing rules. Checks cover the first and last addresses, the upper boundary, and holes between entries.
- A third reference is rejected: 901,593 expanded IP matchers exceed the 750,000-IP configuration budget.
- A category with 500,001 CIDRs is rejected with a diagnostic at the relevant JSON path.

The positive regression failed on unmodified `main` and passes with this change. A separate unit test verifies that the combined budget still rejects additional matchers when it is stricter than the individual IP and domain limits.

Validation results:

- `cargo fmt --all -- --check`: passed.
- Strict Clippy across the workspace, all targets and all features: passed.
- `cargo test --workspace --exclude xray-rust-fuzz --all-targets --locked`: **2,178 passed, 0 failed, 45 ignored**. The ignored tests retain their existing external-resource or Go-oracle requirements.
- Rust documentation with `RUSTDOCFLAGS="-D warnings"`, mobile toolchain checks, and public-fixture checks: passed.
- The generated `config-contract.json` matches the checked-in contract.
- Branch-history checks for retired profile values and Gitleaks 8.30.1: passed, with no new leaks found.
- CLI `config check --json` accepts the actual pinned database pair with `geoip:us`, `geoip:ru`, `geosite:cloudflare`, and `geosite:youtube`: `valid: true`, no diagnostics.

An additional check, `check-benchmark-publication.test.sh`, fails locally on Python 3.14.7 in `malformed_path`: it expects `invalid summary path` but receives `summary path escapes publication root`. The same failure reproduces on unmodified `upstream/main`; both versions reject the invalid path. This script is unchanged by the PR. Validation of the published benchmark record and `bench-xhttp-memory.test.sh` pass.

## Compatibility and security

The maximum permitted parsing work and routing state increase for very large configurations. File and entry size limits, domain and attribute limits, and geodata path checks remain enforced. The CIDR count is checked before protobuf decoding, and repeated references to a cached category still consume the shared matcher budget.

There are no public API/C ABI, protocol, lifecycle, ownership, or threading changes. No configuration fields are added. The documented limits are updated; no performance improvement is claimed.

### Reproduction data

[`geoip.dat` from Loyalsoldier snapshot 202609082347](https://github.com/Loyalsoldier/v2ray-rules-dat/releases/tag/202609082347):

```text
SHA-256: 4149e607530f91da697bad4696f8c59f0a475af38e69405e4124438c9886c721
geoip:us: 300531 CIDRs
US protobuf entry size: 5070814 bytes
```
